### PR TITLE
feat: tags refresh of design and code

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -45,6 +45,9 @@
     "scss/at-rule-no-unknown": true,
     "scss/at-import-no-partial-leading-underscore": null,
     "scss/dollar-variable-pattern": "^^(?!-)(?!.*--)[a-z0-9-]+(?<!-)",
-    "sh-waqar/declaration-use-variable": [['/color/', { ignoreValues: ['transparent', 'inherit'] }]]
+    "sh-waqar/declaration-use-variable": [['/color/', { ignoreValues: ['transparent', 'inherit'] }]],
+    "selector-no-qualifying-type": [ true, {
+      "ignore": [ "class" ]
+    }]
   }
 }

--- a/src/components/tags/_tags.hbs
+++ b/src/components/tags/_tags.hbs
@@ -1,9 +1,8 @@
-<div class="nsw-wysiwyg-content nsw-container">
-	<h1>Tags</h1>
-  <button type="button" class="nsw-tag" aria-pressed="false">Tag</button>
-  <button type="button" class="nsw-tag" aria-pressed="false">LongTag</button>
-  <button type="button" class="nsw-tag" aria-pressed="false">Tag</button>
-  <button type="button" class="nsw-tag" aria-pressed="false">Tag</button>
-  <button type="button" class="nsw-tag" aria-pressed="false">Tag</button>
-  <button type="button" class="nsw-tag is-selected" aria-pressed="true">Selected Tag</button>
+{{#if-equals type "link"}}<a href="#" class="nsw-tag">Link</a>{{/if-equals}}
+{{#if-equals type "text"}}<span class="nsw-tag">Text</span>{{/if-equals}}
+{{#if-equals type "checkbox"}}
+<div class="nsw-tag nsw-tag--checkbox">
+  <input type="checkbox" id="skljhs789js" name="tagInput">
+  <label for="skljhs789js">Checkbox</label>
 </div>
+{{/if-equals}}

--- a/src/components/tags/_tags.scss
+++ b/src/components/tags/_tags.scss
@@ -1,17 +1,21 @@
-.nsw-tag {
-  @include nsw-spacing(margin, lg none );
+.nsw-tag:not(.nsw-tag--checkbox),
+.nsw-tag label {
   @include font-stack;
-  @include nsw-spacing(margin, md xs xs none);
-  @include nsw-spacing(padding, xs sm );
-  @include font-size('sm');
-  @include border-radius;
-  border: 2px solid $light40;
-  background-color: $white;
-  display: inline-block;
+  @include font-size('xs');
+  @include border-radius('tag');
+  @include nsw-spacing(padding-left, md);
+  @include nsw-spacing(padding-right, md);
+  border: solid 1px $nsw-secondary-blue;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  color: $nsw-secondary-blue;
   text-decoration: none;
-  cursor: default;
-  color: $dark80;
+  display: inline-block;
+  background-color: $white;
+}
 
+a.nsw-tag,
+button.nsw-tag {
   &:hover {
     @include nsw-hover;
   }
@@ -19,10 +23,33 @@
   &:focus {
     @include nsw-focus;
   }
+}
 
-  &.is-selected {
+.button.nsw-tag {
+  .is-selected {
     background-color: $nsw-secondary-blue;
-    border-color: $nsw-secondary-blue;
     color: $white;
+  }
+}
+
+.nsw-tag--checkbox {
+  display: inline-block;
+
+  input {
+    position: absolute;
+    opacity: 0;
+
+    &:hover + label {
+      @include nsw-hover;
+    }
+
+    &:focus + label {
+      @include nsw-focus;
+    }
+
+    &:checked + label {
+      background-color: $nsw-secondary-blue;
+      color: $white;
+    }
   }
 }

--- a/src/components/tags/index.hbs
+++ b/src/components/tags/index.hbs
@@ -1,4 +1,11 @@
 ---
 title: Tags
 ---
-{{>_tags}}
+
+<div class="nsw-container">
+  <div style="padding: 1rem">
+    {{>_tags type="link"}}
+    {{>_tags type="text"}}
+    {{>_tags type="checkbox"}}
+  </div>
+</div>

--- a/src/global/handlebars/helpers/if-equals.js
+++ b/src/global/handlebars/helpers/if-equals.js
@@ -1,0 +1,7 @@
+module.exports = function (a, b, options) {
+  if (a == b) {
+    return options.fn(this)
+  }
+
+  return options.inverse(this)
+}

--- a/src/global/scss/settings/_settings.scss
+++ b/src/global/scss/settings/_settings.scss
@@ -36,6 +36,7 @@ $transitions: (
 $border-radii: (
   none: 0,
   default: 4px,
+  tag: 13px,
   round: 50%,
 ) !default;
 

--- a/src/global/scss/tools/_general.scss
+++ b/src/global/scss/tools/_general.scss
@@ -148,8 +148,8 @@
 
 // Border-radius - returns a border-radius from $border-radii map
 @mixin border-radius($type: default) {
-  @if $type != 'none' and $type != 'default' and $type != 'round' {
-    @error 'NSW-DS get-border-radius mixin allows the following values for $type: none, default, round. You have used "#{$type}"';
+  @if $type != 'none' and $type != 'default' and $type != 'round' and $type != 'tag' {
+    @error 'NSW-DS get-border-radius mixin allows the following values for $type: none, default, round, tag. You have used "#{$type}"';
   }
 
   @if $type == 'round' {


### PR DESCRIPTION
- created styles for tags based off plain text, link and checkbox.
- button is still supported but will be removed until a use case is found.
- added rule in style lint to allow qualified selectors, this was used to allow only anchors and buttons to have hover and focus\
- added handlebars helper to render different tags based of parameter
- add another border radius value to mapping and updated the error checking for the mixin