### PR TITLE
fix: sidenav active state

### DIFF
--- a/src/components/side-navigation/_side-navigation.hbs
+++ b/src/components/side-navigation/_side-navigation.hbs
@@ -6,28 +6,28 @@
   <ul class="nsw-sidenav__list nsw-sidenav__list--level-1">
     {{#each navitems}}
       <li class="nsw-sidenav__list-item {{#if (or currentPage navitems) }}has-active-children{{/if}}">
-        <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
+        <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
           {{text}}
         </a>
         {{#if navitems}}
         <ul class="nsw-sidenav__list nsw-sidenav__list--level-2">
           {{#each navitems}}
             <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-              <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
+              <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
                 {{text}}
               </a>
               {{#if navitems}}
               <ul class="nsw-sidenav__list nsw-sidenav__list--level-3">
                 {{#each navitems}}
                   <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-                    <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
+                    <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
                       {{text}}
                     </a>
                     {{#if navitems}}
                     <ul class="nsw-sidenav__list nsw-sidenav__list--level-4">
                       {{#each navitems}}
                         <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-                          <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
+                          <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
                             {{text}}
                           </a>
                         </li>

--- a/src/components/side-navigation/_side-navigation.hbs
+++ b/src/components/side-navigation/_side-navigation.hbs
@@ -5,29 +5,29 @@
   </div>
   <ul class="nsw-sidenav__list nsw-sidenav__list--level-1">
     {{#each navitems}}
-      <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-        <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
+      <li class="nsw-sidenav__list-item {{#if (or currentPage navitems) }}has-active-children{{/if}}">
+        <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
           {{text}}
         </a>
         {{#if navitems}}
         <ul class="nsw-sidenav__list nsw-sidenav__list--level-2">
           {{#each navitems}}
             <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-              <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
+              <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
                 {{text}}
               </a>
               {{#if navitems}}
               <ul class="nsw-sidenav__list nsw-sidenav__list--level-3">
                 {{#each navitems}}
                   <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-                    <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
+                    <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
                       {{text}}
                     </a>
                     {{#if navitems}}
                     <ul class="nsw-sidenav__list nsw-sidenav__list--level-4">
                       {{#each navitems}}
                         <li class="nsw-sidenav__list-item {{#if navitems}}has-active-children{{/if}}">
-                          <a href="{{url}}" class="nsw-sidenav__link {{#if currentPage}}is-current{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}>
+                          <a href="{{url}}" class="nsw-sidenav__link" {{#if currentPage}}aria-current="page"{{/if}}>
                             {{text}}
                           </a>
                         </li>

--- a/src/components/side-navigation/_side-navigation.scss
+++ b/src/components/side-navigation/_side-navigation.scss
@@ -20,9 +20,8 @@
     border-top: solid 1px $light20;
   }
 
-  &__heading-link,
-  &__link {
-    @include nsw-spacing(padding, md);
+  &__heading-link {
+    @include nsw-spacing(padding, xs xs xs none);
     display: block;
     color: $dark80;
     text-decoration: none;
@@ -38,9 +37,26 @@
   }
 
   &__link {
+    @include nsw-spacing(padding, md);
+    display: block;
+    color: $dark80;
+    text-decoration: none;
+    background-color: $white;
+
+    &:hover {
+      @include nsw-hover;
+    }
+
+    &:focus {
+      @include nsw-focus($offset: false);
+    }
+
+    &.is-current {
+      background-color: $light10;
+    }
+
     .has-active-children > & {
       @include font-stack('heading');
-      background-color: $light10;
 
       &:hover {
         @include nsw-hover;

--- a/src/components/side-navigation/_side-navigation.scss
+++ b/src/components/side-navigation/_side-navigation.scss
@@ -38,10 +38,13 @@
   }
 
   &__link {
-    .has-active-children > &,
-    &.is-current {
+    .has-active-children > & {
       @include font-stack('heading');
       background-color: $light10;
+
+      &:hover {
+        @include nsw-hover;
+      }
     }
 
     .nsw-sidenav__list--level-2 & {

--- a/src/global/handlebars/helpers/or.js
+++ b/src/global/handlebars/helpers/or.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return Array.prototype.slice.call(arguments, 0, -1).some(Boolean)
+}


### PR DESCRIPTION
changed html and css to allow active state to show red highlight even if there are no subnavs
adjusted header styles and active states after review of designs