### PR TITLE
set formgroup spacing to medium

### DIFF
--- a/src/components/forms/_forms.scss
+++ b/src/components/forms/_forms.scss
@@ -4,6 +4,10 @@
   }
 }
 
+* + .nsw-form {
+  @include nsw-spacing(margin-top, xxl);
+}
+
 .nsw-form-label {
   @include font-stack(heading);
   @include font-size('sm');

--- a/src/components/forms/_forms.scss
+++ b/src/components/forms/_forms.scss
@@ -280,7 +280,7 @@
 }
 
 * + .nsw-form-group {
-  @include nsw-spacing(margin-top, xxl);
+  @include nsw-spacing(margin-top, md);
   border: 0;
 }
 

--- a/src/components/forms/index.hbs
+++ b/src/components/forms/index.hbs
@@ -11,24 +11,25 @@ title: Forms
             <div class="nsw-col nsw-col-lg-8 nsw-offset-lg-2">
               <h1>Forms</h1>
               <h2>Default Fields</h2>
-              <br>
-              <div class="nsw-forms">
+              <div class="nsw-form">
                 <div class="nsw-form-group">
                   {{>_text-input
                     id="txt1"
                     label="Single-line text input:"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_textarea
                     id="txta1"
                     label="Multi-line text input:"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_select
                     id="select1"
                     label="Select dropdown:"
                   }}
-
+                </div>
                   <div class="nsw-form-checkbox">
                     {{>_checkbox
                       id="check1"
@@ -36,8 +37,6 @@ title: Forms
                       label="Single checkbox:"
                     }}
                   </div>
-                </div>
-
                 <div class="nsw-form-group">
                   <fieldset class="nsw-form-fieldset">
                     <legend>
@@ -45,14 +44,14 @@ title: Forms
                     </legend>
                     <div class="nsw-form-radio">
                       {{>_radio
-                        id="radio1"
-                        name="defaultradio"
-                        label="Radio Option 1"
+                              id="radio1"
+                              name="defaultradio"
+                              label="Radio Option 1"
                       }}
                       {{>_radio
-                        id="radio2"
-                        name="defaultradio"
-                        label="Radio Option 2"
+                              id="radio2"
+                              name="defaultradio"
+                              label="Radio Option 2"
                       }}
                     </div>
                   </fieldset>
@@ -65,14 +64,14 @@ title: Forms
                     </legend>
                     <div class="nsw-form-checkbox">
                       {{>_checkbox
-                        id="checkbox1a"
-                        name="defaultcheck"
-                        label="Checkbox Option 1"
+                              id="checkbox1a"
+                              name="defaultcheck"
+                              label="Checkbox Option 1"
                       }}
                       {{>_checkbox
-                        id="checkbox2a"
-                        name="defaultcheck"
-                        label="Checkbox Option 2"
+                              id="checkbox2a"
+                              name="defaultcheck"
+                              label="Checkbox Option 2"
                       }}
                     </div>
                   </fieldset>
@@ -80,21 +79,22 @@ title: Forms
               </div>
 
               <h2>Fields with Helper text</h2>
-              <br>
-              <div class="nsw-forms">
+              <div class="nsw-form">
                 <div class="nsw-form-group">
                   {{>_text-input
                     id="txt2help"
                     label="Single-line text input field:"
                     helper-text="This is helper text"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_textarea
                     id="txta1help"
                     label="Multi-line text input:"
                     helper-text="This is helper text"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_select
                     id="select1help"
                     label="Select dropdown:"
@@ -144,27 +144,28 @@ title: Forms
               </div>
 
               <h2>Fields with Errors</h2>
-              <br>
-              <div class="nsw-forms">
+              <div class="nsw-form">
                 <div class="nsw-form-group">
                   {{>_text-input
                     id="txt3error"
                     label="Single-line text input field:"
                     error-text="There was an error with the input above"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_textarea
                     id="txta1error"
                     label="Multi-line text input:"
                     error-text="There was an error with the input above"
                   }}
-
+                </div>
+                <div class="nsw-form-group">
                   {{>_select
                     id="select1error"
                     label="Select dropdown:"
                     error-text="There was an error with the input above"
                   }}
-
+                </div>
                   <div class="nsw-form-checkbox">
                     {{>_checkbox
                       id="check1error"
@@ -173,7 +174,6 @@ title: Forms
                       error-text="There was an error with the input above"
                     }}
                   </div>
-                </div>
                 <div class="nsw-form-group">
                   <fieldset class="nsw-form-fieldset" aria-invalid="true">
                     <legend>

--- a/src/components/forms/index.hbs
+++ b/src/components/forms/index.hbs
@@ -44,14 +44,14 @@ title: Forms
                     </legend>
                     <div class="nsw-form-radio">
                       {{>_radio
-                              id="radio1"
-                              name="defaultradio"
-                              label="Radio Option 1"
+                        id="radio1"
+                        name="defaultradio"
+                        label="Radio Option 1"
                       }}
                       {{>_radio
-                              id="radio2"
-                              name="defaultradio"
-                              label="Radio Option 2"
+                        id="radio2"
+                        name="defaultradio"
+                        label="Radio Option 2"
                       }}
                     </div>
                   </fieldset>
@@ -64,14 +64,14 @@ title: Forms
                     </legend>
                     <div class="nsw-form-checkbox">
                       {{>_checkbox
-                              id="checkbox1a"
-                              name="defaultcheck"
-                              label="Checkbox Option 1"
+                        id="checkbox1a"
+                        name="defaultcheck"
+                        label="Checkbox Option 1"
                       }}
                       {{>_checkbox
-                              id="checkbox2a"
-                              name="defaultcheck"
-                              label="Checkbox Option 2"
+                        id="checkbox2a"
+                        name="defaultcheck"
+                        label="Checkbox Option 2"
                       }}
                     </div>
                   </fieldset>

--- a/src/templates/sidebar-empty/index.hbs
+++ b/src/templates/sidebar-empty/index.hbs
@@ -18,14 +18,13 @@ model:
 </div>
 
 <div class="nsw-container nsw-p-top-sm nsw-p-bottom-lg">
-  <div class="nsw-page-layout">  
+  <div class="nsw-page-layout">
     <main id="content" class="nsw-page-layout__main">
+      <h1>Contact us</h1>
+      <p>We welcome your feedback, questions, comments and <a href="#">complaints</a>. We keep customers at the heart of what we do, and use your feedback to improve what we do and how we do it.</p>
+      <p>Including all the information requested will allow us to respond to your query more quickly and accurately.</p>
+      <p>Answer all questions unless they are marked as (optional).</p>
       <form class="nsw-form">
-        <h1>Contact us</h1>
-        <p>We welcome your feedback, questions, comments and <a href="#">complaints</a>. We keep customers at the heart of what we do, and use your feedback to improve what we do and how we do it.</p>
-        <p>Including all the information requested will allow us to respond to your query more quickly and accurately.</p>
-        <p>Answer all questions unless they are marked as (optional).</p>
-
         <div class="nsw-form-group">
           {{>_select
             id="contact-type"
@@ -35,37 +34,44 @@ model:
             option-2="Compliments"
             option-3="Other enquiry"
           }}
-          
+        </div>
+        <div class="nsw-form-group">
           {{>_textarea
             id="contact-feedback"
             label="Give us your feedback:"
             helper-text="The more information you provide, the better we'll be able to action your feedback"
           }}
         </div>
-
+      </form>
         <h2>Personal details</h2>
-
+      <form class="nsw-form">
         <div class="nsw-form-group">
           {{>_text-input
             id="contact-first-name"
             label="First name"
           }}
+        </div>
+        <div class="nsw-form-group">
           {{>_text-input
             id="contact-last-name"
             label="Last name"
           }}
+        </div>
+        <div class="nsw-form-group">
           {{>_text-input
             id="contact-email"
             type="email"
             label="Email address"
           }}
+        </div>
+        <div class="nsw-form-group">
           {{>_text-input
             id="contact-phone"
             type="tel"
             label="Phone number (optional)"
           }}
-        {{>_button-input type="submit" style="primary" text="Submit"}}
         </div>
+        {{>_button-input type="submit" style="primary" text="Submit"}}
       </form>
     </main>
     <div class="nsw-page-layout__sidebar">

--- a/src/templates/sidebar-empty/index.hbs
+++ b/src/templates/sidebar-empty/index.hbs
@@ -42,9 +42,7 @@ model:
             helper-text="The more information you provide, the better we'll be able to action your feedback"
           }}
         </div>
-      </form>
         <h2>Personal details</h2>
-      <form class="nsw-form">
         <div class="nsw-form-group">
           {{>_text-input
             id="contact-first-name"

--- a/src/templates/sidebar-right/index.hbs
+++ b/src/templates/sidebar-right/index.hbs
@@ -21,7 +21,7 @@ model:
 </div>
 
 <div class="nsw-container nsw-p-top-sm nsw-p-bottom-lg">
-  <div class="nsw-page-layout">  
+  <div class="nsw-page-layout">
     <main id="content" class="nsw-page-layout__main">
       <div class="nsw-block">
         <h1>Scaling a design system</h1>
@@ -59,16 +59,20 @@ model:
         <form class="nsw-form" action="#">
           <h4 class="nsw-section-title">Want to stay in touch?</h4>
           <p>Find out about work happening across NSW Government in the digital space. </p>
-          {{>_text-input
-            id="subscribe-full-name"
-            label="Full name"
-            required=true
-          }}
-          {{>_text-input
-            id="subscribe-email"
-            label="Email"
-            required=true
-          }}
+          <div class="nsw-form-group">
+            {{>_text-input
+                    id="subscribe-full-name"
+                    label="Full name"
+                    required=true
+            }}
+          </div>
+          <div class="nsw-form-group">
+            {{>_text-input
+                    id="subscribe-email"
+                    label="Email"
+                    required=true
+            }}
+          </div>
           <div class="nsw-form-checkbox">
             {{>_checkbox
               id="subscribe-tc"

--- a/src/templates/sidebar-right/index.hbs
+++ b/src/templates/sidebar-right/index.hbs
@@ -61,16 +61,16 @@ model:
           <p>Find out about work happening across NSW Government in the digital space. </p>
           <div class="nsw-form-group">
             {{>_text-input
-                    id="subscribe-full-name"
-                    label="Full name"
-                    required=true
+              id="subscribe-full-name"
+              label="Full name"
+              required=true
             }}
           </div>
           <div class="nsw-form-group">
             {{>_text-input
-                    id="subscribe-email"
-                    label="Email"
-                    required=true
+              id="subscribe-email"
+              label="Email"
+              required=true
             }}
           </div>
           <div class="nsw-form-checkbox">


### PR DESCRIPTION
Propose to set spacing to md - 1rem
<img width="580" alt="Screen Shot 2021-04-23 at 12 09 59 pm" src="https://user-images.githubusercontent.com/72421923/115808088-279cc080-a42d-11eb-8e3d-0336fb0e0369.png">

<img width="843" alt="Screen Shot 2021-04-23 at 12 14 07 pm" src="https://user-images.githubusercontent.com/72421923/115808218-70ed1000-a42d-11eb-85a5-a57a5a1583ed.png">


Bootstrap form group class pattern:

```
  <div class="form-group">
    <label for="email">Email address:</label>
    <input type="email" class="form-control" id="email">
  </div>
  <div class="form-group">
    <label for="pwd">Password:</label>
    <input type="password" class="form-control" id="pwd">
  </div>
```