### PR TITLE
Card full modifier

### DIFF
--- a/src/components/card/_card.hbs
+++ b/src/components/card/_card.hbs
@@ -1,4 +1,4 @@
-<div class="nsw-card{{#if headline}} nsw-card--headline{{/if}}{{#if highlight}} nsw-card--highlight{{/if}}{{#if theme}} nsw-card--{{theme}}{{/if}}">
+<div class="nsw-card{{#if headline}} nsw-card--headline{{/if}}{{#if highlight}} nsw-card--highlight{{/if}}{{#if full}} nsw-card--full{{/if}}{{#if theme}} nsw-card--{{theme}}{{/if}}">
   {{#if img}}
   <div class="nsw-card__image">
     <img src="{{img}}" alt="{{heading}}">

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -5,8 +5,7 @@
   overflow: hidden;
   height: 100%;
   color: var(--nsw-text-dark);
-  border-top-left-radius: var(--nsw-border-radius);
-  border-top-right-radius: var(--nsw-border-radius);
+  border-radius: var(--nsw-border-radius);
 
   &:hover {
     color: var(--nsw-text-light);
@@ -63,7 +62,7 @@
     @include font-size('md');
     font-weight: var(--nsw-font-bold);
 
-    a {      
+    a {
       @include pseudo-clickable-block;
       text-decoration: none;
       color: var(--nsw-text-dark);
@@ -122,7 +121,7 @@
     img {
       width: 100%;
       height: 100%;
-      object-fit: cover;      
+      object-fit: cover;
     }
 
     + .nsw-card__content {
@@ -234,6 +233,52 @@
         height: 6px;
         background-color: var(--nsw-brand-accent);
         transition: background $nsw-transition-duration;
+      }
+    }
+  }
+
+  &--full {
+    @include breakpoint('md') {
+      flex-direction: row;
+      align-items: stretch;
+
+      .nsw-card__content {
+        flex: 1 1 50%;
+        height: auto;
+
+        > .nsw-material-icons {
+          left: calc(50% + #{rem(16px)});
+        }
+      }
+
+      .nsw-card__image {
+        flex: 1 1 50%;
+        position: relative;
+        height: auto;
+
+        + .nsw-card__content {
+          border-top-right-radius: var(--nsw-border-radius);
+          border-bottom-left-radius: 0;
+          border-top-width: 1px;
+          border-left-width: 0;
+        }
+      }
+
+      &.nsw-card--highlight {
+        .nsw-card__image::after {
+          top: 0;
+          bottom: 0;
+          left: auto;
+          right: -6px;
+          width: 6px;
+          height: auto;
+        }
+      }
+    }
+
+    @include breakpoint('lg') {
+      .nsw-card__content > .nsw-material-icons {
+        left: calc(50% + #{rem(32px)});
       }
     }
   }

--- a/src/components/card/index.hbs
+++ b/src/components/card/index.hbs
@@ -19,6 +19,8 @@ model:
   card-news-1: ../../components/card/json/card-news-1.json
   card-news-2: ../../components/card/json/card-news-2.json
   card-news-3: ../../components/card/json/card-news-3.json
+  card-media-1: ../../components/card/json/card-media-1.json
+  card-media-2: ../../components/card/json/card-media-2.json
 ---
 
 
@@ -166,6 +168,25 @@ model:
 <div class="nsw-grid">
   <div class="nsw-col nsw-col-md-6 nsw-col-lg-4">
     {{>_card model.card-news-1 highlight=true}}
+  </div>
+</div>
+{{/_docs-example}}
+
+{{#>_docs-example separated="true"}}
+<div class="nsw-grid">
+  <div class="nsw-col nsw-col-lg-6">
+    {{>_card model.card-media-1 full=true}}
+  </div>
+  <div class="nsw-col nsw-col-lg-6">
+    {{>_card model.card-media-2 full=true theme="light"}}
+  </div>
+</div>
+{{/_docs-example}}
+
+{{#>_docs-example}}
+<div class="nsw-grid">
+  <div class="nsw-col nsw-col-lg-6">
+    {{>_card model.card-media-1 full=true highlight=true}}
   </div>
 </div>
 {{/_docs-example}}


### PR DESCRIPTION
Adds card `nsw-card--full` modifier class, as per requirement in nsw.gov.au.
Also fixes the border bottom radius for focus state in all the cards.

The card full modifier displays best if max 2 card are available, and it respects the other modifiers.
On mobile, they look exactly as regular cards.

<img width="1599" alt="Screen Shot 2021-11-10 at 10 11 54 am" src="https://user-images.githubusercontent.com/5859926/141020627-0df4df08-3871-4a62-ade2-2b6a6d0d0eae.png">
<img width="816" alt="Screen Shot 2021-11-10 at 10 12 33 am" src="https://user-images.githubusercontent.com/5859926/141020650-49eac29a-bfc3-4a0f-81f7-f02a43342717.png">
<img width="461" alt="Screen Shot 2021-11-10 at 10 13 15 am" src="https://user-images.githubusercontent.com/5859926/141020655-cf9b79b7-ca2f-4883-aeca-88473c545a56.png">


**NB:** starterkit not updated!
