### PR TITLE
Fix sizing of video's when using a `<video>` tag within an `nsw-media__video` class

### DIFF
--- a/src/components/media/_media.scss
+++ b/src/components/media/_media.scss
@@ -71,7 +71,8 @@
       padding-top: 56.25%;
     }
 
-    iframe {
+    iframe,
+    video {
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
The video portion of the _Media_ component currently assumes that the video will be an iFrame, such as when embedding a YouTube video as demonstrated on the [documentation page for the _Media_ component](https://digitalnsw.github.io/nsw-design-system/components/media/index.html). However, developers may wish to use content stored on the same domain, where a `<video>` tag is more likely to be used. This PR adds the video tag to the list of selectors that can be used within an element with the `nsw-media__video` class.