### PR TITLE
Allow header search button to be a link as well as a button

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -28,7 +28,7 @@
 
   &__menu,
   &__search {
-    button {      
+    button, a {      
       @include font-size('xxs');
       font-weight: var(--nsw-font-bold);
       border-radius: var(--nsw-border-radius);


### PR DESCRIPTION
Currently, the search button in the header styling is geared towards use as a button. This leaves out anybody who has JS disabled/ the JS has failed for some reason. This small change allows the search button to be a `<a>` as well as a button, opening up progressive enhancement opportunities for developers.