### PR TITLE
bugfix/toggletip

### DIFF
--- a/src/components/tooltip/toggletip.js
+++ b/src/components/tooltip/toggletip.js
@@ -14,6 +14,7 @@ class Toggletip {
     this.toggletipId = this.toggletip.getAttribute('aria-controls')
     this.toggletipElement = document.querySelector(`#${this.toggletipId}`)
     this.toggletipContent = false
+    this.toggletipAnchor = this.toggletip.querySelector('[data-anchor]') || this.toggletip
     this.toggletipText = this.toggletip.innerText
     this.toggletipHeading = this.toggletip.getAttribute('data-title') || this.toggletipText
     this.arrowElement = false
@@ -126,7 +127,7 @@ class Toggletip {
     this.toggletipIsOpen = false
   }
 
-  updateToggletip(toggletip, arrowElement, anchor = this.toggletip) {
+  updateToggletip(toggletip, arrowElement, anchor = this.toggletipAnchor) {
     computePosition(anchor, toggletip, {
       placement: 'top',
       middleware: [

--- a/src/components/tooltip/toggletip.js
+++ b/src/components/tooltip/toggletip.js
@@ -13,7 +13,7 @@ class Toggletip {
     this.toggletip = element
     this.toggletipId = this.toggletip.getAttribute('aria-controls')
     this.toggletipElement = document.querySelector(`#${this.toggletipId}`)
-    this.toggletipContent = this.toggletipElement.innerHTML
+    this.toggletipContent = false
     this.toggletipText = this.toggletip.innerText
     this.toggletipHeading = this.toggletip.getAttribute('data-title') || this.toggletipText
     this.arrowElement = false
@@ -73,6 +73,7 @@ class Toggletip {
 
   createToggletipElement() {
     if (this.toggletipElement) {
+      this.toggletipContent = this.toggletipElement.innerHTML
       this.toggletipElement.innerHTML = ''
       const createToggletip = `
       <div class="nsw-toggletip__header">

--- a/src/components/tooltip/toggletip.js
+++ b/src/components/tooltip/toggletip.js
@@ -41,6 +41,10 @@ class Toggletip {
       }
     })
 
+    window.addEventListener('DOMContentLoaded', () => {
+      this.toggletipContent = this.toggletipElement.innerHTML
+    })
+
     this.toggletipElement.addEventListener('keydown', this.trapFocus.bind(this))
 
     window.addEventListener('click', (event) => {
@@ -73,7 +77,6 @@ class Toggletip {
 
   createToggletipElement() {
     if (this.toggletipElement) {
-      this.toggletipContent = this.toggletipElement.innerHTML
       this.toggletipElement.innerHTML = ''
       const createToggletip = `
       <div class="nsw-toggletip__header">


### PR DESCRIPTION
This fix addresses a bug in the Toggletip component that was causing limitations in DOM modifications specifically related to the Toggletip content. Previously, there were issues preventing the proper manipulation and rendering of the Toggletip content within the DOM.