### PR TITLE
fix/breadcrumbs-icons

### DIFF
--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -13,6 +13,7 @@
 
     &::before {
       @include material-icons;
+      content: 'keyboard_arrow_right';
       content: 'keyboard_arrow_right' / '';
       font-size: rem(map-get($nsw-icon-sizes, 20));
       line-height: rem(8px);
@@ -61,6 +62,27 @@
 
       .nsw-section--invert & {    
         color: var(--nsw-text-light);
+      }
+    }
+  }
+}
+
+@supports (content: 'x' / 'y') {
+  .nsw-breadcrumbs {  
+    li {
+      &::before {
+        content: 'keyboard_arrow_right' / '';
+      }
+    }
+  }
+}
+
+@media speech {
+  .nsw-breadcrumbs {  
+    li {
+      &::before {
+        display: none;
+        visibility: hidden;
       }
     }
   }


### PR DESCRIPTION
Added support for Firefox and Safari who do not support content alternate text