### PR TITLE
fix/issue-394/utility-list

### DIFF
--- a/src/components/utility-list/utility-list.js
+++ b/src/components/utility-list/utility-list.js
@@ -23,8 +23,11 @@ class UtilityList extends Toggletip {
     })
 
     this.share.addEventListener('click', (event) => {
-      event.preventDefault()
       const button = event.target.closest('a')
+      if (!button) return
+
+      event.preventDefault()
+
       const social = button.getAttribute('data-social')
       const url = this.getSocialUrl(button, social)
       if (social === 'mail') {


### PR DESCRIPTION
Added if (!button) return;

**return on No Match:** The function returns immediately if the clicked item isn't one of the buttons, ensuring that other clicks to open the tooltip or within the tooltip don’t trigger unwanted behaviour.