### PR TITLE
fix(ally): Ensure buttons have discernible text

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -193,6 +193,10 @@ $nsw-form-tick: '<svg fill="#ffffff" version="1.1" xmlns="http://www.w3.org/2000
         border-color: var(--nsw-grey-01);
         border-left-width: 0;
 
+        .nsw-material-icons:first-child {
+          margin-right: 0;
+        }
+
         .nsw-section--invert & {  
           color: var(--nsw-white);
           border-color: var(--nsw-white);

--- a/src/components/form/partials/_input-group.hbs
+++ b/src/components/form/partials/_input-group.hbs
@@ -1,5 +1,5 @@
 <div class="nsw-form__input-group{{#if icon}} nsw-form__input-group--icon{{/if}}{{#if large}} nsw-form__input-group--large{{/if}}">
   <label class="sr-only" for="{{id}}">{{label}}</label>
   <input class="nsw-form__input" type="text" id="{{id}}" name="{{id}}" value="{{value}}"{{#if predictive}} aria-autocomplete="list" autocomplete="off"{{/if}}>
-  <button class="nsw-button {{#if white}}nsw-button--white{{else}}nsw-button--dark{{/if}} nsw-button--flex" type="submit">{{#if icon}}<span class="material-icons nsw-material-icons" focusable="false" aria-hidden="true">{{icon}}</span>{{else}}{{label}}{{/if}}</button>
+  <button class="nsw-button {{#if white}}nsw-button--white{{else}}nsw-button--dark{{/if}} nsw-button--flex" type="submit">{{#if icon}}<span class="material-icons nsw-material-icons" focusable="false" aria-hidden="true">{{icon}}</span><span class="sr-only">{{label}}</span>{{else}}{{label}}{{/if}}</button>
 </div>


### PR DESCRIPTION
We're using the nsw-design system in a storybook setup.
In that setup we have storybook's test runner using playwright to do axe testing of a11y.
The search input when there's an icon is failing with a critical error 'Ensure buttons have discernible text'. This is because the icon is the only markup inside the button, and this is set to aria-hidden=false.
This change creates a minor visual difference in it's current form.
