### PR TITLE
fix(carousel): Role=group not valid inside a list

### DIFF
--- a/src/components/card-carousel/carousel.js
+++ b/src/components/card-carousel/carousel.js
@@ -76,7 +76,6 @@ class Carousel extends SwipeContent {
 
     const itemsArray = Array.from(this.items)
     itemsArray.forEach((element, index) => {
-      element.setAttribute('role', 'group')
       element.setAttribute('aria-roledescription', 'slide')
       element.setAttribute('aria-label', `${index + 1} of ${itemsArray.length}`)
       element.setAttribute('data-index', index)


### PR DESCRIPTION
We're using the design system in a storybook setup.
With this setup we're using storybook's test runner to test a11y of our components using axe/playwright.
It is failing for the carousel component with an invalid list structure/role attribute. `role="group"` is not valid inside a list.
