### PR TITLE
Set breadcrumb ellipsis to open once on click instead of blocking user navigation

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.js
+++ b/src/components/breadcrumbs/breadcrumbs.js
@@ -10,16 +10,14 @@ class Breadcrumbs {
     if (this.allBreadcrumbs.children.length > 3) {
       this.createToggle()
     }
-
-    this.element.addEventListener('click', (event) => {
-      event.preventDefault()
-      this.allBreadcrumbs.classList.toggle('nsw-breadcrumbs__show-all')
-    })
   }
 
   createToggle() {
     const toggle = this.constructor.createElement('li', ['nsw-breadcrumbs__show-more-toggle'])
     toggle.innerHTML = '<button aria-label="Show more breadcrumbs" class="nsw-breadcrumbs__toggle-button" type="button">…</button>'
+    toggle.addEventListener('click', () => {
+      this.allBreadcrumbs.classList.toggle('nsw-breadcrumbs__show-all')
+    })
 
     this.allBreadcrumbs.insertBefore(toggle, this.secondBreadcrumb)
   }


### PR DESCRIPTION
Addresses [issue 516](https://github.com/digitalnsw/nsw-design-system/issues/516)
