### PR TITLE
Fix(file-upload): ensure files with long names are fully removed from input

### DIFF
--- a/src/components/file-upload/_guidance.hbs
+++ b/src/components/file-upload/_guidance.hbs
@@ -25,7 +25,7 @@ layout: blank-layout.hbs
 
 <h3>Upload status</h3>
 
-<div class="nsw-m-top-xs nsw-in-page-alert nsw-in-page-alert--info nsw-in-page-alert--compact">
+<div class="nsw-in-page-alert nsw-in-page-alert--info nsw-in-page-alert--compact nsw-m-top-xs">
   <span class="material-icons nsw-material-icons nsw-in-page-alert__icon" focusable="false" aria-hidden="true">info</span>
   <div class="nsw-in-page-alert__content">
     <p class="nsw-small">This functionailty is not included in the base component.</p>
@@ -54,6 +54,18 @@ layout: blank-layout.hbs
 </div>
 
 <h3>Multiple uploads</h3>
+
+<div class="nsw-in-page-alert nsw-in-page-alert--info nsw-in-page-alert--compact nsw-m-top-xs">
+  <span class="material-icons nsw-material-icons nsw-in-page-alert__icon" focusable="false" aria-hidden="true">info</span>
+  <div class="nsw-in-page-alert__content">
+    <p class="nsw-small">
+      To enable multiple file uploads, add the <code>multiple</code> attribute to the file input. 
+      To replace existing files instead of appending new ones, use the <code>data-replace-files</code> attribute on the file upload container. 
+      <strong>Do not use both attributes simultaneously</strong>, as they conflict. Enabling both will cause unintended behavior.
+    </p>
+  </div>
+</div>
+
 <p>Clearly communicate if a user can upload multiple files and consider displaying additional files vertically.</p>
 
 <div class="nsw-grid">

--- a/src/components/file-upload/blank.hbs
+++ b/src/components/file-upload/blank.hbs
@@ -14,7 +14,6 @@ page: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     accept=true
     multiple=true
-    replace=true
     }}
   </div>
 </div>
@@ -28,6 +27,7 @@ page: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     error-text="The selected file must be smaller than 350MB"
     accept=true
+    multiple=true
     }}
   </div>
 </div>
@@ -42,7 +42,6 @@ page: true
     label="Upload drivers license"
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     accept=true
-    multiple=true
     replace=true
     }}
   </div>
@@ -57,6 +56,7 @@ page: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     error-text="The selected file must be smaller than 350MB"
     accept=true
+    multiple=true
     }}
   </div>
 </div>

--- a/src/components/file-upload/file-upload.js
+++ b/src/components/file-upload/file-upload.js
@@ -22,6 +22,7 @@ class FileUpload {
     }
 
     this.input.addEventListener('change', this.handleInputChange.bind(this))
+    this.element.addEventListener('click', this.handleFileRemove.bind(this))
   }
 
   handleInputChange() {
@@ -61,32 +62,40 @@ class FileUpload {
     this.filesList.classList.add('active')
 
     const dataTransfer = new DataTransfer()
+    const existingFiles = new Set()
 
+    if (this.replaceFiles) {
+      this.filesList.innerHTML = ''
+      this.currentFiles = new DataTransfer()
+    }
+
+    // Collect existing files to maintain them in the list (if multiple is allowed)
+    if (this.multipleUpload && this.currentFiles && this.currentFiles.files) {
+      for (let i = 0; i < this.currentFiles.files.length; i += 1) {
+        const file = this.currentFiles.files[i]
+        dataTransfer.items.add(file)
+        existingFiles.add(file.name)
+      }
+    }
+
+    let fileListHTML = ''
+
+    // Add only new files
     for (let i = 0; i < this.input.files.length; i += 1) {
       const file = this.input.files[i]
-      dataTransfer.items.add(file)
+      if (!existingFiles.has(file.name)) {
+        dataTransfer.items.add(file)
+        fileListHTML += this.createFileItem(file)
+      }
     }
 
     this.currentFiles = dataTransfer
-    let fileListHTML = ''
 
-    for (let i = 0; i < this.input.files.length; i += 1) {
-      const file = this.input.files[i]
-      fileListHTML = this.createFileItem(file) + fileListHTML
-    }
-
-    if (this.replaceFiles) {
-      this.filesList.innerHTML = fileListHTML
-    } else {
+    if (fileListHTML) {
       this.filesList.insertAdjacentHTML('beforeend', fileListHTML)
     }
 
     this.input.files = this.currentFiles.files
-    this.removeFile()
-  }
-
-  removeFile() {
-    this.filesList.addEventListener('click', this.handleFileRemove.bind(this))
   }
 
   handleFileRemove(event) {

--- a/src/components/file-upload/file-upload.js
+++ b/src/components/file-upload/file-upload.js
@@ -93,7 +93,7 @@ class FileUpload {
     if (!event.target.closest('.nsw-icon-button')) return
     event.preventDefault()
     const item = event.target.closest('.nsw-file-upload__item')
-    const filename = item.querySelector('.nsw-file-upload__item-filename').dataset.filename
+    const { filename } = item.querySelector('.nsw-file-upload__item-filename').dataset
 
     const dataTransfer = new DataTransfer()
     for (let i = 0; i < this.currentFiles.files.length; i += 1) {

--- a/src/components/file-upload/file-upload.js
+++ b/src/components/file-upload/file-upload.js
@@ -49,6 +49,7 @@ class FileUpload {
 
     li.insertAdjacentHTML('afterbegin', html)
     li.querySelector('.nsw-file-upload__item-filename').textContent = this.constructor.truncateString(file.name, 50)
+    li.querySelector('.nsw-file-upload__item-filename').dataset.filename = file.name
     return li.outerHTML
   }
 
@@ -92,7 +93,7 @@ class FileUpload {
     if (!event.target.closest('.nsw-icon-button')) return
     event.preventDefault()
     const item = event.target.closest('.nsw-file-upload__item')
-    const filename = item.querySelector('.nsw-file-upload__item-filename').textContent
+    const filename = item.querySelector('.nsw-file-upload__item-filename').dataset.filename
 
     const dataTransfer = new DataTransfer()
     for (let i = 0; i < this.currentFiles.files.length; i += 1) {

--- a/src/components/file-upload/index.hbs
+++ b/src/components/file-upload/index.hbs
@@ -9,6 +9,8 @@ meta-description: File uploaders help users to select and upload files.
 meta-index: true
 ---
 
+<h3>Error messages</h3>
+<p>Includes ability to accept only a single file.</p>
 {{#>_docs-example}}
 <div class="nsw-form">
   <div class="nsw-form__group">
@@ -18,13 +20,14 @@ meta-index: true
     label="Upload drivers license"
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     accept=true
-    multiple=true
+    replace=true
     }}
   </div>
 </div>
 {{/_docs-example}}
 
 <h3>Error messages</h3>
+<p>Includes ability to accept multiple files.</p>
 {{#>_docs-example}}
 <div class="nsw-form">
   <div class="nsw-form__group">
@@ -35,6 +38,7 @@ meta-index: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     error-text="The selected file must be smaller than 350MB"
     accept=true
+    multiple=true
     }}
   </div>
 </div>

--- a/src/components/file-upload/theme.hbs
+++ b/src/components/file-upload/theme.hbs
@@ -14,7 +14,6 @@ page: true
     label="Upload drivers license"
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     accept=true
-    multiple=true
     replace=true
     }}
   </div>
@@ -29,6 +28,7 @@ page: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     error-text="The selected file must be smaller than 350MB"
     accept=true
+    multiple=true
     }}
   </div>
 </div>
@@ -43,7 +43,6 @@ page: true
     label="Upload drivers license"
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     accept=true
-    multiple=true
     replace=true
     }}
   </div>
@@ -58,6 +57,7 @@ page: true
     helper-text="Formats accepted: JPG, PNG or PDF <br /> File size must not exceed 350MB"
     error-text="The selected file must be smaller than 350MB"
     accept=true
+    multiple=true
     }}
   </div>
 </div>


### PR DESCRIPTION
Files with names longer than 50 characters were removed from the list but remained in the input field. This fix ensures the file is completely removed from both the list and input.

Closes [#518](https://github.com/digitalnsw/nsw-design-system/issues/518)