### PR TITLE
fix(tabs): correct aria-labelledby attribute

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -57,8 +57,7 @@ class Tabs {
   enhanceTabPanel(panel, id) {
     const panelElem = panel
     panelElem.setAttribute('role', 'tabpanel')
-    panelElem.setAttribute('role', 'tabpanel')
-    panelElem.setAttribute('aria-labelledBy', id)
+    panelElem.setAttribute('aria-labelledby', id)
     panelElem.setAttribute('tabindex', '0')
     panelElem.hidden = true
     this.tabPanel.push(panelElem)


### PR DESCRIPTION
## Summary
- fix duplicate role attr in tab panel setup
- use proper aria-labelledby attribute in tab panel

## Testing
- `npx eslint src/components/tabs/tabs.js`


------
https://chatgpt.com/codex/tasks/task_b_68a7dae4e8dc832c8678f9631a3ba6a6