### PR TITLE
Handle null anchors in main nav focus check

### DIFF
--- a/src/components/main-nav/main-nav.js
+++ b/src/components/main-nav/main-nav.js
@@ -256,7 +256,8 @@ class Navigation {
   checkIfContainsFocus(e) {
     const { linkParent } = this.whichSubNavLatest()
     const focusWithin = linkParent.contains(e.target)
-    const isButton = e.target.closest('a').getAttribute('role') === 'button'
+    const anchor = e.target.closest('a')
+    const isButton = anchor && anchor.getAttribute('role') === 'button'
     if (!focusWithin && isButton) {
       this.toggleSubNavDesktop()
     }


### PR DESCRIPTION
Addresses an important edge case in the main navigation component regarding focus checks for anchor elements. 

### Motivation
In the current implementation, if an event is triggered on an element that is not an anchor (`<a>`), the code attempts to access the role attribute without first verifying that an anchor actually exists. This can lead to runtime errors when `closest('a')` returns `null`. By adding a null check for the anchor element, we prevent potential crashes and ensure the application behaves more robustly.

### Improvements
- **Error Prevention**: This change eliminates the risk of encountering `TypeError` due to attempting to access attributes on a null reference.
- **Enhanced User Experience**: By ensuring that the focus check operates correctly regardless of the event target, we maintain a smoother navigation experience for users, particularly in cases where the focus might unexpectedly shift to non-anchor elements.

Overall, this update improves the reliability and user experience of the navigation component, contributing to a more stable application.