### PR TITLE
fix: reset multi-select options when clearing filters

### DIFF
--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -214,7 +214,6 @@ class Filters {
           option.value = ''
         } else if (option.type === 'select-one') {
           if (this.selectedOption) {
-            console.log(Array.from(option.options).indexOf(this.selectedOption))
             option.selectedIndex = Array.from(option.options).indexOf(this.selectedOption)
           } else {
             option.selectedIndex = 0
@@ -236,7 +235,7 @@ class Filters {
 
       multiSelectOptions.forEach((element) => {
         element.setAttribute('aria-selected', 'true')
-        element.dispatchEvent(new Event(simulateEvent))
+        element.dispatchEvent(simulateEvent)
         element.click()
       })
     }


### PR DESCRIPTION
### Pull Request Description

**Title:** fix: reset multi-select options when clearing filters

**Motivation:**
This pull request addresses an issue where multi-select options do not reset correctly when filters are cleared. Users expect that all filter selections revert to their default state, and failing to do so can lead to confusion and an inconsistent user experience.

**Changes Made:**
- Removed the unnecessary console log statement that was previously used for debugging.
- Updated the event dispatch logic for multi-select options to ensure that the correct state is applied when filters are cleared.

**Improvements:**
By implementing these changes, we enhance the functionality of the filter component, ensuring that users have a clear and intuitive experience. This fix contributes to the overall reliability of the filtering system, which is crucial for maintaining user trust and satisfaction.