### PR TITLE
fix: handle accordion hidden attribute

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -55,7 +55,7 @@ class Accordion {
 
       if (contentElem) {
         contentElem.id = buttonElem.getAttribute('aria-controls')
-        contentElem.hidden = 'until-found'
+        contentElem.setAttribute('hidden', 'until-found')
         this.content.push(contentElem)
       }
 
@@ -92,11 +92,11 @@ class Accordion {
     if (state === 'open') {
       element.classList.add('active')
       element.setAttribute('aria-expanded', 'true')
-      targetContent.hidden = false
+      targetContent.removeAttribute('hidden')
     } else if (state === 'close') {
       element.classList.remove('active')
       element.setAttribute('aria-expanded', 'false')
-      targetContent.hidden = 'until-found'
+      targetContent.setAttribute('hidden', 'until-found')
     }
   }
 
@@ -105,17 +105,17 @@ class Accordion {
     const targetContent = this.getTargetContent(currentTarget)
 
     if (targetContent) {
-      const isHidden = targetContent.hidden
+      const isHidden = targetContent.hasAttribute('hidden')
 
-      if ((isHidden === true) || (isHidden === 'until-found')) {
+      if (isHidden) {
         this.setAccordionState(currentTarget, 'open')
       } else {
         this.setAccordionState(currentTarget, 'close')
       }
 
       if (this.expandAllBtn && this.collapseAllBtn) {
-        this.expandAllBtn.disabled = this.content.every((item) => item.hidden === false)
-        this.collapseAllBtn.disabled = this.content.every((item) => item.hidden === 'until-found')
+        this.expandAllBtn.disabled = this.content.every((item) => !item.hasAttribute('hidden'))
+        this.collapseAllBtn.disabled = this.content.every((item) => item.hasAttribute('hidden'))
       }
     }
   }


### PR DESCRIPTION
### Pull Request Description: fix: handle accordion hidden attribute

This pull request addresses an issue with how the hidden attribute is managed within the Accordion component. The previous implementation incorrectly used the `hidden` property as a boolean, which led to inconsistencies in the visibility behavior of accordion items.

#### Motivation
The primary motivation behind this change is to enhance the accessibility and functionality of the Accordion component. By using the `setAttribute` and `hasAttribute` methods, we ensure that the hidden attribute is handled correctly, allowing for better control over the visibility of content sections. This aligns with best practices for managing HTML attributes and improves the overall user experience.

#### Key Changes
- Updated the way the hidden attribute is assigned and checked:
  - Changed `contentElem.hidden = 'until-found'` to `contentElem.setAttribute('hidden', 'until-found')`.
  - Modified checks for hidden state from `targetContent.hidden` to `targetContent.hasAttribute('hidden')`.
- Adjusted logic in the `setAccordionState` method to ensure proper state management based on the hidden attribute.

#### Benefits
- Improved accessibility by ensuring that the accordion respects the hidden attribute correctly.
- Enhanced maintainability of the code by adhering to standard practices for attribute management.
- Reduced potential for bugs related to visibility toggling, leading to a more reliable user interface.

By implementing these changes, we aim to provide a more robust and user-friendly Accordion component that functions as intended across different scenarios.