### PR TITLE
fix: exclude draggable elements from focusable selection

### DIFF
--- a/src/global/scripts/helpers/utilities.js
+++ b/src/global/scripts/helpers/utilities.js
@@ -22,7 +22,7 @@ export const getFocusableElement = (el) => {
   const elementArr = [].slice.call(el.querySelectorAll(`a[href],button:not([disabled]),
   area[href],input:not([disabled]):not([type=hidden]),
   select:not([disabled]),textarea:not([disabled]),
-  iframe,object,embed,*:not(.is-draggabe)[tabindex],
+  iframe,object,embed,*:not(.is-draggable)[tabindex],
   *[contenteditable]`))
 
   return focusObjectGenerator(elementArr)

--- a/src/global/scripts/helpers/utilities.test.js
+++ b/src/global/scripts/helpers/utilities.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs')
+const path = require('path')
+const vm = require('vm')
+const assert = require('assert')
+
+const filePath = path.resolve(__dirname, 'utilities.js')
+let code = fs.readFileSync(filePath, 'utf8')
+
+// Remove import lines and convert ES module syntax to CommonJS
+code = code
+  .replace(/\s*import[^\n]*\n/, '')
+  .replace(/export const /g, 'const ')
+  .concat('\nmodule.exports = { getFocusableElement, focusObjectGenerator };')
+
+const sandbox = { module: { exports: {} } }
+vm.runInNewContext(code, sandbox)
+const { getFocusableElement } = sandbox.module.exports
+
+class NodeListLike {
+  constructor(items) {
+    this.length = items.length
+    items.forEach((item, i) => { this[i] = item })
+  }
+}
+
+const link = { id: 'link' }
+const drag = { id: 'drag', className: 'is-draggable' }
+const box = { id: 'box' }
+
+const fakeEl = {
+  querySelectorAll: (selector) => {
+    const items = selector.includes('.is-draggable') ? [link, box] : [link, drag, box]
+    return new NodeListLike(items)
+  },
+}
+
+const result = getFocusableElement(fakeEl)
+
+assert.strictEqual(result.length, 2)
+assert.ok(result.all.every((el) => el.id !== 'drag'))
+
+console.log('Focus handling test passed')


### PR DESCRIPTION
## Summary
- fix query selector typo to exclude `.is-draggable` items from focusable elements
- add test verifying draggable elements are not returned as focusable

## Testing
- `npx eslint src/global/scripts/helpers/utilities.js src/global/scripts/helpers/utilities.test.js`
- `node src/global/scripts/helpers/utilities.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a80ae6f6e4832ca86477bdc511d490