### PR TITLE
Fix focusable selectors and swipe handler cleanup

### DIFF
--- a/src/components/card-carousel/carousel.js
+++ b/src/components/card-carousel/carousel.js
@@ -9,7 +9,7 @@ class Carousel extends SwipeContent {
     this.controlClass = 'js-carousel__control'
     this.wrapperClass = 'js-carousel__wrapper'
     this.counterClass = 'js-carousel__counter'
-    this.counterTorClass = 'js-carousel__counter-tot'
+    this.counterTotalClass = 'js-carousel__counter-tot'
     this.navClass = 'js-carousel__navigation'
     this.navItemClass = 'js-carousel__nav-item'
     this.navigationItemClass = this.element.getAttribute('data-navigation-item-class') ? this.element.getAttribute('data-navigation-item-class') : 'nsw-carousel__nav-item'
@@ -29,7 +29,7 @@ class Carousel extends SwipeContent {
     this.items = this.list ? this.list.getElementsByTagName('li') : false
     this.controls = this.element.querySelectorAll(`.${this.controlClass}`)
     this.counter = this.element.querySelectorAll(`.${this.counterClass}`)
-    this.counterTor = this.element.querySelectorAll(`.${this.counterTorClass}`)
+    this.counterTotal = this.element.querySelectorAll(`.${this.counterTotalClass}`)
     this.ariaLabel = this.element.getAttribute('data-description') ? this.element.getAttribute('data-description') : 'Card carousel'
     this.dragEnabled = !!((this.element.getAttribute('data-drag') && this.element.getAttribute('data-drag') === 'on'))
     this.loop = !!((this.element.getAttribute('data-loop') && this.element.getAttribute('data-loop') === 'on'))
@@ -632,7 +632,7 @@ class Carousel extends SwipeContent {
   }
 
   initCarouselCounter() {
-    if (this.counterTor.length > 0) this.counterTor[0].textContent = this.itemsNb
+    if (this.counterTotal.length > 0) this.counterTotal[0].textContent = this.itemsNb
     this.setCounterItem()
   }
 

--- a/src/components/card-carousel/swipe-content.js
+++ b/src/components/card-carousel/swipe-content.js
@@ -12,19 +12,20 @@ class SwipeContent {
     this.dragging = false
     this.intervalId = false
     this.changedTouches = false
+    this.handleEventBind = this.handleEvent.bind(this)
   }
 
   init() {
-    this.element.addEventListener('mousedown', this.handleEvent.bind(this))
-    this.element.addEventListener('touchstart', this.handleEvent.bind(this), { passive: true })
+    this.element.addEventListener('mousedown', this.handleEventBind)
+    this.element.addEventListener('touchstart', this.handleEventBind, { passive: true })
   }
 
   initDragging() {
-    this.element.addEventListener('mousemove', this.handleEvent.bind(this))
-    this.element.addEventListener('touchmove', this.handleEvent.bind(this), { passive: true })
-    this.element.addEventListener('mouseup', this.handleEvent.bind(this))
-    this.element.addEventListener('mouseleave', this.handleEvent.bind(this))
-    this.element.addEventListener('touchend', this.handleEvent.bind(this))
+    this.element.addEventListener('mousemove', this.handleEventBind)
+    this.element.addEventListener('touchmove', this.handleEventBind, { passive: true })
+    this.element.addEventListener('mouseup', this.handleEventBind)
+    this.element.addEventListener('mouseleave', this.handleEventBind)
+    this.element.addEventListener('touchend', this.handleEventBind)
   }
 
   cancelDragging() {
@@ -36,11 +37,11 @@ class SwipeContent {
       }
       this.intervalId = false
     }
-    this.element.removeEventListener('mousemove', this.handleEvent.bind(this))
-    this.element.removeEventListener('touchmove', this.handleEvent.bind(this))
-    this.element.removeEventListener('mouseup', this.handleEvent.bind(this))
-    this.element.removeEventListener('mouseleave', this.handleEvent.bind(this))
-    this.element.removeEventListener('touchend', this.handleEvent.bind(this))
+    this.element.removeEventListener('mousemove', this.handleEventBind)
+    this.element.removeEventListener('touchmove', this.handleEventBind)
+    this.element.removeEventListener('mouseup', this.handleEventBind)
+    this.element.removeEventListener('mouseleave', this.handleEventBind)
+    this.element.removeEventListener('touchend', this.handleEventBind)
   }
 
   handleEvent(event) {

--- a/src/global/scripts/helpers/utilities.js
+++ b/src/global/scripts/helpers/utilities.js
@@ -22,7 +22,7 @@ export const getFocusableElement = (el) => {
   const elementArr = [].slice.call(el.querySelectorAll(`a[href],button:not([disabled]),
   area[href],input:not([disabled]):not([type=hidden]),
   select:not([disabled]),textarea:not([disabled]),
-  iframe,object,embed,*:not(.is-draggabe)[tabindex],
+  iframe,object,embed,*:not(.is-draggable)[tabindex],
   *[contenteditable]`))
 
   return focusObjectGenerator(elementArr)
@@ -43,7 +43,7 @@ export const trapTabKey = (event, focusObject) => {
   const { activeElement } = document
   const focusableElement = focusObject
 
-  if (event.keyCode !== 9) return false
+  if (event.key !== 'Tab' && event.keyCode !== 9) return false
 
   if (focusableElement.length === 1) {
     event.preventDefault()


### PR DESCRIPTION
## Summary
- correct draggable selector and Tab key detection in utility helpers
- fix typo in carousel counter property
- ensure swipe event listeners are properly removed

## Testing
- `npm run types`
- `npx eslint src/global/scripts/helpers/utilities.js src/components/card-carousel/carousel.js src/components/card-carousel/swipe-content.js >/tmp/eslint.log && tail -n 20 /tmp/eslint.log`


------
https://chatgpt.com/codex/tasks/task_b_68a8e40d41b0832cbaf0117997a2631f