### PR TITLE
Updates colour theming criteria for clarity

### DIFF
--- a/src/docs/content/design/theming.hbs
+++ b/src/docs/content/design/theming.hbs
@@ -121,7 +121,7 @@ meta-index: true
 
 <ul>
   <li><strong>Brand Dark</strong> - the primary interaction colour and is used for buttons, text links, icons, dark variants of components and backgrounds. To ensure the required 4.5:1 contrast ratio for accessibility, this colour must always be selected from row 01 of the NSW Government colour palette.</li>
-  <li><strong>Brand Light</strong> - your contrasting colour to Brand Dark and is used for secondary buttons, light variants of components, backgrounds and content sections. To ensure the required 4.5:1 contrast ratio for accessibility, this colour must be a light colour. Acceptable colour options for Brand Light include rows 03 or 04 of the NSW Government colour palette.</li>
+  <li><strong>Brand Light</strong> - your contrasting colour to Brand Dark and is used for secondary buttons, light variants of components, backgrounds and content sections. To ensure the required 4.5:1 contrast ratio for accessibility, this colour must be a light colour. Acceptable colour options for Brand Light are rows 03 or 04 of the NSW Government colour palette. Colours from row 02 cannot be used.</li>
   <li><strong>Brand Supplementary</strong> - an optional third colour which should be used sparingly in instances such as pictograms, dark variants of components and background. To ensure the required 4.5:1 contrast ratio for accessibility, this colour must be a <strong>dark colour</strong>.</li>
   <li><strong>Brand Accent</strong> - the highlight colour to capture attention and draw the users eye. You’ll find its use in highlight bars and pictograms. This colour has different selection rules depending on your brand classification.</li>
 </ul>
@@ -211,7 +211,7 @@ meta-index: true
 <h2 id="corporate">Masterbrand corporate</h2>
 <p>The only defined colour for masterbrand corporate is Brand Dark (Blue 01). Brand Light, Supplementary and Accent are variable colours and can be altered if required. If you wish to change a variable brand colour, it must be selected from the blue, red or grey colour sets and:</p>
 <ul>
-  <li><strong>Brand Light</strong> must be a light colour (accessible with Text Dark).</li>
+  <li><strong>Brand Light</strong> must be selected from rows 03 or 04 only (accessible with Text Dark). Colours from row 02 cannot be used.</li>
   <li><strong>Brand Supplementary</strong> must be a dark colour (accessible with Text Light).</li>
   <li><strong>Brand Accent</strong> can be selected from any row in wider colour palette (row 02 and 03 recommended).</li>
 </ul>
@@ -234,8 +234,8 @@ meta-index: true
 <p>Colour selection rules:</p>
 <ul>
   <li><strong>Brand Dark</strong> must be selected from row 01.</li>
-  <li><strong>Brand Light</strong> must be a light colour (accessible with Text Dark, row 03 and 04 recommended).</li>
-  <li><strong> Brand Supplementary</strong> must be a dark colour (accessible with Text Light). This is an additional colour option only available if your Brand Light is not from row 02.</li>
+  <li><strong>Brand Light</strong> must be selected from rows 03 or 04 only (accessible with Text Dark). Colours from row 02 cannot be used.</li>
+  <li><strong> Brand Supplementary</strong> must be a dark colour (accessible with Text Light). This is an optional additional colour that should be used sparingly.</li>
   <li><strong> Brand Accent</strong> can be selected from any row from your chosen colour sets (row 02 and 03 recommended).</li>
 </ul>
 <p>Guidance on applying your new brand colours in Figma can be found on the <strong>Colour</strong> page of the <a href="/docs/content/design/figma-ui-kit.html">Figma UI Kit</a>.</p>


### PR DESCRIPTION
Updates the criteria for selecting "Brand Light" colors in our theming documentation to enhance clarity and ensure compliance with accessibility standards. 

The changes specify that "Brand Light" must be selected exclusively from rows 03 or 04 of the NSW Government color palette, explicitly stating that colors from row 02 are not permitted. This adjustment helps eliminate ambiguity regarding acceptable color options, ensuring that all design elements maintain the required 4.5:1 contrast ratio for accessibility.

By clarifying these criteria, we improve the overall consistency and usability of our design system, making it easier for developers and designers to adhere to best practices in color selection. This will lead to more accessible applications and a better user experience.