### PR TITLE
Fixes alignment issue with card carousel.

### DIFF
--- a/src/components/card-carousel/_carousel.scss
+++ b/src/components/card-carousel/_carousel.scss
@@ -165,7 +165,6 @@
   &__item {
     flex-shrink: 0;
     width: var(--nsw-carousel-item-auto-size, 300px);
-    margin-bottom: 0.5rem;
     opacity: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
Addresses a visual alignment issue with the card carousel component. The previous margin-right value of `1.5rem` on the carousel items was causing inconsistent spacing between the cards, leading to a misaligned appearance. 

By removing the margin-right, we ensure that the cards are evenly spaced and visually cohesive, enhancing the overall user experience. This fix improves the layout and presentation of the carousel, making it more aesthetically pleasing and functional.