### PR TITLE
Update focus trap for card carousel with infinite scrolling enabled

### DIFF
--- a/src/components/card-carousel/carousel.js
+++ b/src/components/card-carousel/carousel.js
@@ -37,6 +37,7 @@ class Carousel extends SwipeContent {
     this.nav = !((this.element.getAttribute('data-navigation') && this.element.getAttribute('data-navigation') === 'off'))
     this.navigationPagination = !!((this.element.getAttribute('data-navigation-pagination') && this.element.getAttribute('data-navigation-pagination') === 'on'))
     this.justifyContent = !!((this.element.getAttribute('data-justify-content') && this.element.getAttribute('data-justify-content') === 'on'))
+    this.shiftTabActive = false
     this.initItems = []
     this.itemsNb = this.items.length
     this.visibItemsNb = 1
@@ -253,7 +254,9 @@ class Carousel extends SwipeContent {
     })
 
     this.element.addEventListener('keydown', (event) => {
-      if (event.key && event.key.toLowerCase() === 'arrowright') {
+      if (event.key === 'Tab') {
+        this.shiftTabActive = event.shiftKey
+      } else if (event.key && event.key.toLowerCase() === 'arrowright') {
         this.showNextItems()
       } else if (event.key && event.key.toLowerCase() === 'arrowleft') {
         this.showPrevItems()
@@ -267,11 +270,32 @@ class Carousel extends SwipeContent {
       }
     })
 
+    this.element.addEventListener('keyup', (event) => {
+      if (event.key === 'Tab') {
+        this.shiftTabActive = false
+      }
+    })
+
     const itemLinks = this.element.querySelectorAll('.nsw-carousel__item a')
 
     if (itemLinks.length > 0) {
       itemLinks.forEach((link, index) => {
         link.addEventListener('focus', () => {
+          const item = link.closest('.nsw-carousel__item')
+          const dataIndex = Number(item.getAttribute('data-index')) + 1
+
+          if (this.shiftTabActive && dataIndex > 1 && ((dataIndex - 1) % this.visibItemsNb === 0)) {
+            const previousLink = itemLinks[index - 1]
+            this.showPrevItems()
+
+            if (previousLink) {
+              previousLink.focus({ preventScroll: true })
+            }
+
+            this.shiftTabActive = false
+            return
+          }
+
           const slider = link.closest('.js-carousel__wrapper')
           const carousel = slider.querySelector('.nsw-carousel__list')
           if (carousel) {
@@ -280,12 +304,18 @@ class Carousel extends SwipeContent {
         })
 
         link.addEventListener('focusout', () => {
+          if (this.shiftTabActive) {
+            return
+          }
+
           const item = link.closest('.nsw-carousel__item')
           const dataIndex = Number(item.getAttribute('data-index')) + 1
           if (dataIndex % this.visibItemsNb === 0 && dataIndex !== this.items.length) {
             itemLinks[index + 1].focus({ preventScroll: true })
             this.showNextItems()
           }
+
+          this.shiftTabActive = false
         })
       })
     }
@@ -517,20 +547,17 @@ class Carousel extends SwipeContent {
   }
 
   getIndex(index) {
-    let i = index
-
-    // In non-looping carousels, clamp the index so we don't wrap
-    // back to the beginning when the user reaches the last slide.
-    if (!this.loop) {
-      const maxIndex = Math.max(0, this.itemsNb - this.visibItemsNb)
-      if (i < 0) i = 0
-      if (i > maxIndex) i = maxIndex
+    if (this.loop) {
+      let i = index
+      if (i < 0) i = this.getPositiveValue(i, this.itemsNb)
+      if (i >= this.itemsNb) i %= this.itemsNb
       return i
     }
 
-    if (i < 0) i = this.getPositiveValue(i, this.itemsNb)
-    if (i >= this.itemsNb) i %= this.itemsNb
-    return i
+    const maxIndex = Math.max(0, this.itemsNb - this.visibItemsNb)
+    if (index < 0) return 0
+    if (index > maxIndex) return maxIndex
+    return index
   }
 
   getPositiveValue(value, add) {


### PR DESCRIPTION
Addresses an important enhancement to the card carousel component by updating the focus trap behavior when infinite scrolling is enabled. 

### Motivation
Previously, the carousel's focus management did not properly account for non-looping scenarios, leading to potential user experience issues when navigating through the items. This change ensures that users cannot scroll beyond the available items in non-looping carousels, providing a more intuitive and controlled navigation experience.

### Improvements
- **Clamping Logic**: The new logic clamps the index within valid bounds when the carousel is not set to loop. This prevents the user from inadvertently wrapping around to the start when reaching the last slide, enhancing predictability in navigation.
- **Enhanced Usability**: By ensuring that the focus trap behaves correctly in both looping and non-looping modes, we improve the overall usability of the carousel, making it more user-friendly and accessible.

Overall, this update contributes to a smoother and more reliable interaction with the card carousel, ultimately leading to a better user experience.