### PR TITLE
Update npm-publish workflow permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Updates the permissions in the `npm-publish` workflow to allow writing access to the repository contents. 

**Motivation:**
Previously, the workflow only had read access to the contents, which restricted our ability to publish packages effectively. By changing the permission to write, we can now automatically update package versions and publish changes directly from the CI workflow without manual intervention.

**Improvements:**
This enhancement streamlines our publishing process, allowing for a more efficient development cycle. It reduces the risk of errors and delays associated with manual publishing, ultimately enabling us to deliver updates to our users more quickly and reliably.