### PR TITLE
Update npm publish workflow and revert package version to 3.24.0

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,18 +15,21 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          always-auth: true
       - run: . ./build-script/verify-branch.sh ${GITHUB_REF##*/}
       - run: |
           npm ci
           npm run release:${{ github.event.inputs.semver }}
+          git fetch origin
+          git pull --rebase origin ${GITHUB_REF##*/}
+          git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config --global user.name ${{ github.actor }}
           npm run commit && npm run git-tag
       - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nsw-design-system",
-  "version": "3.25.0",
+  "version": "3.24.0",
   "description": "Design system for Digital NSW",
   "main": "dist/js/main.js",
   "types": "dist/js/main.d.ts",


### PR DESCRIPTION
Updates the npm publish workflow and reverts the package version to 3.24.0. 

### Motivation for Changes:
1. **Workflow Update**: The workflow has been modified to use specific versions of the GitHub Actions for better stability and compatibility. By reverting to `actions/checkout@v4` and `actions/setup-node@v4`, we aim to ensure consistent behavior and avoid potential issues that may arise from newer versions.

2. **Authentication Improvements**: The addition of `always-auth: true` in the Node setup step ensures that authentication is consistently applied during package publication, which is crucial for maintaining access to private registries and ensuring a smooth deployment process.

3. **Version Reversion**: The package version has been reverted to 3.24.0. This may be necessary to align with other dependencies or to address issues found in the 3.25.0 release. By reverting to a stable version, we can ensure that users have a reliable experience while we work on any necessary improvements or fixes.

### Benefits:
- **Increased Stability**: By locking in specific action versions, we reduce the risk of unexpected behavior in our CI/CD pipeline.
- **Enhanced Authentication**: The change to npm authentication improves the security and reliability of our package publishing process.
- **Reliability for Users**: Reverting to a previous version allows us to maintain a stable release for users while we address any concerns with the latest version.

Overall, these changes enhance the reliability and security of our package publishing workflow, ensuring a smoother experience for both developers and users.