### PR TITLE
Revert version relating to npm publish issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nsw-design-system",
-  "version": "3.25.0",
+  "version": "3.23.0",
   "description": "Design system for Digital NSW",
   "main": "dist/js/main.js",
   "types": "dist/js/main.d.ts",


### PR DESCRIPTION
Reverts the version of the `nsw-design-system` package from `3.25.0` to `3.23.0` in response to an issue encountered during the npm publish process. 

The recent version introduced changes that led to complications with the publishing workflow, impacting our ability to release updates seamlessly. By reverting to the previous stable version, we aim to restore functionality and ensure that our publishing pipeline operates smoothly.

This change is crucial for maintaining the stability of our releases and allowing us to address any underlying issues with the new version before attempting to publish it again.