### PR TITLE
Updates publish package build script

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,16 +22,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: false
+          cache: npm
 
       - name: Upgrade npm for OIDC trusted publishing
         run: |


### PR DESCRIPTION
Updates the build script for publishing packages to leverage the latest versions of GitHub Actions and improve our CI workflow.

### Changes Made:
1. **Checkout Action**: Upgraded from `actions/checkout@v4` to `actions/checkout@v6`, which includes performance improvements and additional features such as better handling of tags.
2. **Setup Node Action**: Updated from `actions/setup-node@v4` to `actions/setup-node@v6`, enhancing our Node.js setup process and enabling npm caching to speed up subsequent builds.

### Motivation:
These updates ensure that our CI pipeline benefits from the latest enhancements in GitHub Actions, leading to more efficient builds and improved package publishing processes. The use of npm caching will significantly reduce build times, allowing for faster iterations and deployments. Overall, this change aims to enhance the reliability and performance of our package publishing workflow.