### PR TITLE
Update casing of nav items for DS docs site

### DIFF
--- a/src/docs/content/utilities/box-shadow.hbs
+++ b/src/docs/content/utilities/box-shadow.hbs
@@ -1,5 +1,5 @@
 ---
-title: Box Shadow
+title: Box shadow
 width: narrow
 intro: Utility for adding the NSW box-shadow to an element.
 no-blank: true

--- a/src/global/handlebars/layouts/partials/_docs-nav.hbs
+++ b/src/global/handlebars/layouts/partials/_docs-nav.hbs
@@ -144,7 +144,7 @@
 
     <li>
       <a role="button" aria-expanded="false" aria-controls="sub-nav-utilities">
-        <span>Utility Classes</span>
+        <span>Utility classes</span>
         <span class="material-icons nsw-material-icons" focusable="false" aria-hidden="true">keyboard_arrow_right</span>
       </a>
 


### PR DESCRIPTION
Updates the casing of navigation items on the design system documentation site to ensure consistency and adherence to standard styling guidelines. 

Specifically, the title "Box Shadow" has been changed to "Box shadow" to align with the convention of using lowercase for non-proper nouns in titles. Additionally, "Utility Classes" has been updated to "Utility classes" in the navigation menu. 

These changes enhance the overall readability and professionalism of the documentation site, creating a more cohesive user experience. Consistent casing not only improves aesthetics but also helps users navigate the documentation with greater ease.