### PR TITLE
Docs - Update page title logic

### DIFF
--- a/src/global/handlebars/layouts/layout.hbs
+++ b/src/global/handlebars/layouts/layout.hbs
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
-  <title>NSW Digital Design System{{#unless home}} - {{title}}{{/unless}}</title>
+  <title>{{#if home}}NSW Digital Design System{{else}}{{title}} - NSW Digital Design System{{/if}}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/global/handlebars/layouts/partials/_docs-iframe.hbs
+++ b/src/global/handlebars/layouts/partials/_docs-iframe.hbs
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NSW Digital Design System - Component Demo</title>
+  <title>Component Demo - NSW Digital Design System</title>
   <meta name="robots" content="noindex" />
   <meta name="description" content="">
   <meta name="keywords" content="">


### PR DESCRIPTION
This pull request updates the HTML page titles in the Handlebars layout templates to improve consistency and clarity in the document titles across the site.

Improvements to HTML page titles:

* Updated the `<title>` logic in `layout.hbs` so that the home page uses "NSW Digital Design System", while all other pages use the format "{{title}} - NSW Digital Design System" for better clarity and SEO.
* Changed the title in `_docs-iframe.hbs` to "Component Demo - NSW Digital Design System" for consistency with the main site title format.