### PR TITLE
Bugfix – focus loss for cookie consent confirmation step

### DIFF
--- a/src/components/cookie-consent/cookie-consent.js
+++ b/src/components/cookie-consent/cookie-consent.js
@@ -232,6 +232,10 @@ class CookieConsent {
 
   createConsentBanner() {
     const { language: { translations: { en } } } = this.config
+    const { consentModal } = en
+    const bannerOffset = consentModal.bannerOffset ? consentModal.bannerOffset : '0'
+    this.consentBannerConfirmationMessage = consentModal.confirmationMessage || ''
+
     // Prevent multiple instances by reusing an existing banner if present
     const containerEl = stickyContainer()
     const existingBanner = containerEl.querySelector('.nsw-cookie-banner')
@@ -239,9 +243,6 @@ class CookieConsent {
       this.consentBannerElement = existingBanner
       return
     }
-    const { consentModal } = en
-    const bannerOffset = consentModal.bannerOffset ? consentModal.bannerOffset : '0'
-    this.consentBannerConfirmationMessage = consentModal.confirmationMessage || ''
 
     const consentBannerHtml = `
       <div class="nsw-cookie-banner" role="alert" tabindex="-1" aria-labelledby="cookie-banner-title" aria-live="assertive" style="bottom: ${bannerOffset};">

--- a/src/components/cookie-consent/cookie-consent.js
+++ b/src/components/cookie-consent/cookie-consent.js
@@ -447,30 +447,36 @@ class CookieConsent {
 
     this.consentSelectionMade = true
 
-    this.showConfirmationMessage()
-
-    // Hide banner if present or confirmation is present
-    if (!this.consentBannerConfirmationMessage) {
+    if (this.consentBannerConfirmationMessage) {
+      this.showConfirmationMessage()
+    } else {
       this.hideConsentBanner()
     }
   }
 
   showConfirmationMessage() {
+    this.consentBannerElement.style.display = 'block'
+    this.consentBannerElement.removeAttribute('hidden')
+
     // Select the confirmation message element
     const confirmationMessage = this.consentBannerElement.querySelector('.nsw-cookie-banner__confirmation-message')
 
     // Select the description element
     const description = this.consentBannerElement.querySelector('.nsw-cookie-banner__description')
+    let focusTarget = this.consentBannerElement
 
     if (confirmationMessage) {
       // Change the hidden attribute to false for the confirmation message
       confirmationMessage.removeAttribute('hidden')
+      focusTarget = confirmationMessage.querySelector('.js-dismiss-cookie-banner') || focusTarget
     }
 
     if (description) {
       // Change the hidden attribute to true for the description
       description.setAttribute('hidden', 'true')
     }
+
+    focusTarget.focus()
   }
 
   showConsentBanner() {


### PR DESCRIPTION
This pull request updates the behavior of the cookie consent banner to improve accessibility and user experience when displaying the confirmation message after a user makes a consent selection. The main changes ensure the banner remains visible when showing the confirmation and that focus is managed correctly for accessibility.

**Improvements to cookie consent banner behavior and accessibility:**

* The banner now stays visible when a confirmation message is shown, instead of being hidden immediately after a consent selection. (`src/components/cookie-consent/cookie-consent.js`)
* When the confirmation message is shown, the banner's display is explicitly set to visible and the `hidden` attribute is removed to ensure it is accessible. (`src/components/cookie-consent/cookie-consent.js`)
* Focus is programmatically moved to the confirmation message's dismiss button (if present) or to the banner itself, improving accessibility for keyboard and assistive technology users. (`src/components/cookie-consent/cookie-consent.js`)