### PR TITLE
Change from digital@ to designsystem@ mailbox

### DIFF
--- a/src/docs/content/about/release-notes.hbs
+++ b/src/docs/content/about/release-notes.hbs
@@ -1134,7 +1134,7 @@ meta-index: true
         <td>Human Centred Design Comprac</td>
         <td>10 Mar 2022</td>
         <td>11am - 12pm</td>
-        <td><a href="mailto:digital@customerservice.nsw.gov.au">Email us</a></td>
+        <td><a href="mailto:designsystem@customerservice.nsw.gov.au">Email us</a></td>
       </tr>
       </tbody>
     </table>

--- a/src/docs/content/about/what-is-design-system.hbs
+++ b/src/docs/content/about/what-is-design-system.hbs
@@ -116,6 +116,6 @@ meta-index: true
 
 <h2>Support</h2>
 <h3>Questions</h3>
-<p>If you have any questions or would like to chat to us further about using the NSW Design System reach out to us at <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au.</a></p>
+<p>If you have any questions or would like to chat to us further about using the NSW Design System reach out to us at <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au</a>.</p>
 <h3>Report issues</h3>
 <p>View and raise issues and bugs through our <a href="https://github.com/digitalnsw/nsw-design-system/issues" aria-label="Link to view the current and/or resolve issues on Github for the NSW Design System" target="_blank">Issues tracker</a> on Github or via <a href="https://community.digital.nsw.gov.au/c/components/report-a-bug/27" aria-label="Link to engage with the NSW Design System community and report a bug" target="_blank">Report a bug</a> on the Community.</p>

--- a/src/docs/content/about/what-is-design-system.hbs
+++ b/src/docs/content/about/what-is-design-system.hbs
@@ -27,7 +27,7 @@ meta-index: true
 <li>Regularly review and update your product to maintain accessibility.</li>
 </ul>
 
-<p>For additional support, explore our <a href="https://www.digital.nsw.gov.au/delivery/accessibility-and-inclusivity-toolkit/courses" aria-label="Link to the Accessibility and Inclusivity Toolkit on the Digital NSW website" target="_blank">digital accessibility training resources</a>. Alternatively, contact <a href="mailto:digital@customerservice.nsw.gov.au">our team</a> for implementation advice.</p>
+<p>For additional support, explore our <a href="https://www.digital.nsw.gov.au/delivery/accessibility-and-inclusivity-toolkit/courses" aria-label="Link to the Accessibility and Inclusivity Toolkit on the Digital NSW website" target="_blank">digital accessibility training resources</a>. Alternatively, contact <a href="mailto:designsystem@customerservice.nsw.gov.au">our team</a> for implementation advice.</p>
 
 <h3 id="wcag-compliance">Design System Updates for WCAG 2.2 Compliance</h3>
 <p>We've updated the components in the NSW Design System to achieve compliance with WCAG 2.2 Level AA. Please review your digital products to determine if adjustments are needed to align with these updates.</p>
@@ -116,6 +116,6 @@ meta-index: true
 
 <h2>Support</h2>
 <h3>Questions</h3>
-<p>If you have any questions or would like to chat to us further about using the NSW Design System reach out to us at <a href="mailto:digital@customerservice.nsw.gov.au">digital@customerservice.nsw.gov.au.</a></p>
+<p>If you have any questions or would like to chat to us further about using the NSW Design System reach out to us at <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au.</a></p>
 <h3>Report issues</h3>
 <p>View and raise issues and bugs through our <a href="https://github.com/digitalnsw/nsw-design-system/issues" aria-label="Link to view the current and/or resolve issues on Github for the NSW Design System" target="_blank">Issues tracker</a> on Github or via <a href="https://community.digital.nsw.gov.au/c/components/report-a-bug/27" aria-label="Link to engage with the NSW Design System community and report a bug" target="_blank">Report a bug</a> on the Community.</p>

--- a/src/docs/content/contribute/propose-a-new-component.hbs
+++ b/src/docs/content/contribute/propose-a-new-component.hbs
@@ -35,7 +35,7 @@ meta-index: true
       <p>Propose your component along with evidence of the user need it will help solve, as well as any links to examples of it in use, or screenshots.</p>
       <ul>
         <li><strong>Digital NSW community platform</strong> - Post your component suggestion in the <a href="https://community.digital.nsw.gov.au/c/components/suggest-a-component/9">suggest a component</a> thread.</li>
-        <li><strong>Email us</strong> - Email your component suggestion to <a href="mailto:digital@customerservice.nsw.gov.au">digital@customerservice.nsw.gov.au</a></li>
+        <li><strong>Email us</strong> - Email your component suggestion to <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au</a></li>
       </ul>
     </div>
   </div>

--- a/src/docs/content/design/extending.hbs
+++ b/src/docs/content/design/extending.hbs
@@ -29,5 +29,5 @@ meta-index: true
 
 <h2>Contributing back</h2>
 <p>Whether proposing a component or building a new one, its your contribution that will help us deliver better services for NSW.</p>
-<p>If you build a component or user journey that doesn’t exist in the NSW Design System, please share it with us via the <a target="_blank" href="https://community.digital.nsw.gov.au/">community</a> or email us at <a href="mailto:digital@customerservice.nsw.gov.au">digital@customerservice.nsw.gov.au</a>.
+<p>If you build a component or user journey that doesn’t exist in the NSW Design System, please share it with us via the <a target="_blank" href="https://community.digital.nsw.gov.au/">community</a> or email us at <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au</a>.
   Your contributions help us grow the design system and help others create engaging and user-focused NSW Government digital products and services.</p>

--- a/src/docs/content/design/figma-ui-kit.hbs
+++ b/src/docs/content/design/figma-ui-kit.hbs
@@ -33,7 +33,7 @@ meta-index: true
 
 <p>For NSW Government teams, partners, and vendors who need access to the managed version of the NSW Design System UI Kit. Using this method, components stay up-to-date with the latest release. When library updates are available, the Libraries icon on the Assets tab in the left sidebar will display a blue badge.</p>
 
-<p>To request view access, email <a href="mailto:digital@customerservice.nsw.gov.au">digital@customerservice.nsw.gov.au</a>.</p>
+<p>To request view access, email <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au</a>.</p>
 
 <p>View access lets you copy components into your design files, perform basic inspection, and comment. Edit access is reserved for the internal NSW Design System team only.</p>
 
@@ -41,7 +41,7 @@ meta-index: true
 
 <p>A downloadable version of the NSW Design System UI Kit, for exploration or evaluation, is available upon request. You can import the file to your own workspace and publish it as a local library. <strong>Offline copies don&rsquo;t receive any updates</strong> and your design files will be out of date when we publish a new version.</p>
 
-<p>To request an offline copy of the Figma UI Kit, email <a href="mailto:digital@customerservice.nsw.gov.au">digital@customerservice.nsw.gov.au</a>.</p>
+<p>To request an offline copy of the Figma UI Kit, email <a href="mailto:designsystem@customerservice.nsw.gov.au">designsystem@customerservice.nsw.gov.au</a>.</p>
 
 <h2 id="getting-started">Getting started with Figma</h2>
 

--- a/src/global/handlebars/layouts/layout.hbs
+++ b/src/global/handlebars/layouts/layout.hbs
@@ -78,7 +78,7 @@
               <li><a href="https://github.com/digitalnsw/nsw-design-system" target="_blank">Github</a></li>
               <li><a href="https://www.figma.com/design/PVrERKnckLTlJSPk12gbtS/NSW-Digital-Design-System?node-id=18830-13437&p=f&t=wz6pwwPdSDJOHzk2-0" target="_blank">Figma</a></li>
               <li><a href="https://confirmsubscription.com/h/i/73DE733140B743AF" target="_blank">Sign up</a></li>
-              <li><a href="mailto:digital@customerservice.nsw.gov.au">Contact us</a></li>
+              <li><a href="mailto:designsystem@customerservice.nsw.gov.au">Contact us</a></li>
             </ul>
             <div class="nsw-footer__info">
               <div class="nsw-footer__copyright">Copyright © <script>document.write(new Date().getFullYear())</script></div>

--- a/src/templates/homepage/featured-list.hbs
+++ b/src/templates/homepage/featured-list.hbs
@@ -123,7 +123,7 @@ model:
             <div class="nsw-col nsw-col-lg-6">
               {{>_content-block 
                 heading="Contact us"
-                copy="If you would like to get in contact with us, or have any other questions, email us at  <a href='mailto:digital@customerservice.nsw.gov.au'>digital@customerservice.nsw.gov.au</a>. We can organise a time to meet up.  "
+                copy="If you would like to get in contact with us, or have any other questions, email us at  <a href='mailto:designsystem@customerservice.nsw.gov.au'>designsystem@customerservice.nsw.gov.au</a>. We can organise a time to meet up.  "
               }}
             </div>
           </div>


### PR DESCRIPTION
This pull request updates all references to the NSW Design System team's contact email across the documentation and site templates. The previous email address (`digital@customerservice.nsw.gov.au`) has been replaced with the new, more specific email (`designsystem@customerservice.nsw.gov.au`). This ensures consistency and directs enquiries to the correct team.

**Contact email updates across documentation and site:**

* Updated all documentation pages (including support, contribution, and component proposal sections) to use `designsystem@customerservice.nsw.gov.au` instead of the old team email. [[1]](diffhunk://#diff-b567cd7abee13924f90f0dedec8f332157b2427c5a5717f1d11ec9b1cd170eb4L30-R30) [[2]](diffhunk://#diff-b567cd7abee13924f90f0dedec8f332157b2427c5a5717f1d11ec9b1cd170eb4L119-R119) [[3]](diffhunk://#diff-115509f7854b3f42bf6d24878fb7d7315c8131901dc3f0dfe4d0c8ab8614aa01L32-R32) [[4]](diffhunk://#diff-eeee541bb04f66f14bad6007d2bd0108a11a3cef7c9f0b09751098541141f78dL38-R38) [[5]](diffhunk://#diff-38fd410a922195a553cb6354c74cf3e12ffa8088efffe55f84471ca8422722f1L36-R44) [[6]](diffhunk://#diff-984de00ac4f3b250e1a9c9f2852b037ca95b8e3f437a01cf33a305fef7a99c11L1137-R1137)
* Changed the footer and homepage "Contact us" links to use the new email address for user enquiries. [[1]](diffhunk://#diff-0b7f7373a166f8fd13b7a5a5fa68a27096ccd2566ce18efb7cce616f63844d82L81-R81) [[2]](diffhunk://#diff-6e52610ffe2c78dae31a0f215ffe766ae2a35401b54b3454b7004929717bc82fL126-R126)