### PR TITLE
Updates breakpoint description that increases logic clarity.

### DIFF
--- a/src/core/grid/_guidance.hbs
+++ b/src/core/grid/_guidance.hbs
@@ -6,13 +6,14 @@ layout: blank-layout.hbs
 <p class="nsw-intro">The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints. </p>
 
 <h2 class="nsw-h3">Breakpoints</h2>
+<p>The Sass breakpoint tokens define the minimum viewport width where each breakpoint starts. The ranges below show where each breakpoint is active before the next breakpoint starts.</p>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
   <div class="nsw-table nsw-table--valign-middle">
     <table>
       <thead>
         <tr>
           <th>Breakpoint</th>
-          <th>Token</th>
+          <th>Token (min-width)</th>
           <th style="max-width: 120px;">Container offset (fixed)</th>
           <th style="max-width: 100px;">Gutters (fixed)</th>
           <th style="max-width: 120px;">Max active content area</th>
@@ -21,35 +22,35 @@ layout: blank-layout.hbs
       <tbody>
         <tr>
           <td>xs (Extra Small)<br />0-575px</td>
-          <td><code>breakpoints-xs</code></td>
+          <td><code>breakpoints-xs</code><br />0</td>
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
         </tr>
         <tr>
           <td>sm (Small)<br />576-767px</td>
-          <td><code>breakpoints-sm</code></td>
+          <td><code>breakpoints-sm</code><br />576px</td>
           <td>16px</td>
           <td>16px</td>
           <td>735px</td>
         </tr>
         <tr>
           <td>md (Medium)<br />768-991px</td>
-          <td><code>breakpoints-md</code></td>
+          <td><code>breakpoints-md</code><br />768px</td>
           <td>16px</td>
           <td>32px  </td>
           <td>959px</td>
         </tr>
         <tr>
           <td>lg (Large)<br />992-1199px</td>
-          <td><code>breakpoints-lg</code></td>
+          <td><code>breakpoints-lg</code><br />992px</td>
           <td>16px</td>
           <td>32px</td>
           <td>1167px</td>
         </tr>
         <tr>
           <td>xl (Extra Large)<br />1200px+</td>
-          <td><code>breakpoints-xl</code></td>
+          <td><code>breakpoints-xl</code><br />1200px</td>
           <td>16px</td>
           <td>32px</td>
           <td>1168px</td>

--- a/src/core/grid/index.hbs
+++ b/src/core/grid/index.hbs
@@ -21,13 +21,14 @@ meta-index: true
 
 <h2 id="breakpoints">Breakpoints</h2>
 <p>The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints.</p>
+<p>The Sass breakpoint tokens define the minimum viewport width where each breakpoint starts. The ranges below show where each breakpoint is active before the next breakpoint starts.</p>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
   <div class="nsw-table nsw-table--valign-middle">
     <table>
       <thead>
         <tr>
           <th>Breakpoint</th>
-          <th>Token</th>
+          <th>Token (min-width)</th>
           <th style="max-width: 120px;">Container offset (fixed)</th>
           <th style="max-width: 100px;">Gutters (fixed)</th>
           <th style="max-width: 120px;">Max active content area</th>
@@ -36,35 +37,35 @@ meta-index: true
       <tbody>
         <tr>
           <td>xs (Extra Small)<br/>0-575px</td>
-          <td><code>breakpoints-xs</code></td>
+          <td><code>breakpoints-xs</code><br/>0</td>
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
         </tr>
         <tr>
           <td>sm (Small)<br/>576-767px</td>
-          <td><code>breakpoints-sm</code></td>
+          <td><code>breakpoints-sm</code><br/>576px</td>
           <td>16px</td>
           <td>16px</td>
           <td>735px</td>
         </tr>
         <tr>
           <td>md (Medium)<br/>768-991px</td>
-          <td><code>breakpoints-md</code></td>
+          <td><code>breakpoints-md</code><br/>768px</td>
           <td>16px</td>
           <td>32px</td>
           <td>959px</td>
         </tr>
         <tr>
           <td>lg (Large)<br/>992-1199px</td>
-          <td><code>breakpoints-lg</code></td>
+          <td><code>breakpoints-lg</code><br/>992px</td>
           <td>16px</td>
           <td>32px</td>
           <td>1167px</td>
         </tr>
         <tr>
           <td>xl (Extra Large)<br/>1200px+</td>
-          <td><code>breakpoints-xl</code></td>
+          <td><code>breakpoints-xl</code><br/>1200px</td>
           <td>16px</td>
           <td>32px</td>
           <td>1168px</td>


### PR DESCRIPTION
This pull request improves the documentation for grid breakpoints in the NSW Design System by clarifying the meaning of the breakpoint tokens and explicitly showing the minimum viewport width for each breakpoint. The changes make it easier for users to understand when each breakpoint becomes active and what the associated Sass tokens represent.

Documentation clarity and detail improvements:

* Added explanatory text to both `src/core/grid/index.hbs` and `src/core/grid/_guidance.hbs` to clarify that Sass breakpoint tokens define the minimum viewport width where each breakpoint starts, and that the displayed ranges show where each breakpoint is active. [[1]](diffhunk://#diff-78c67d0b2a0f60327814c490f2639fdd41b31ec8703085c6e52fee119f204fd6R24-R31) [[2]](diffhunk://#diff-de0c0f8d596b8eec9b6ce59340f817d1aff207c2a16a8877a588773d61a84139R9-R16)
* Updated the table headers from "Token" to "Token (min-width)" to explicitly indicate that the tokens correspond to minimum viewport widths. [[1]](diffhunk://#diff-78c67d0b2a0f60327814c490f2639fdd41b31ec8703085c6e52fee119f204fd6R24-R31) [[2]](diffhunk://#diff-de0c0f8d596b8eec9b6ce59340f817d1aff207c2a16a8877a588773d61a84139R9-R16)
* Enhanced the breakpoint token table rows to display the actual minimum width for each breakpoint alongside the Sass token (e.g., `<code>breakpoints-md</code><br/>768px>`), making the information more explicit and accessible. [[1]](diffhunk://#diff-78c67d0b2a0f60327814c490f2639fdd41b31ec8703085c6e52fee119f204fd6L39-R68) [[2]](diffhunk://#diff-de0c0f8d596b8eec9b6ce59340f817d1aff207c2a16a8877a588773d61a84139L24-R53)