### PR TITLE
Add release notes for version 3.24.10 with logo asset updates

### DIFF
--- a/src/docs/content/about/release-notes.hbs
+++ b/src/docs/content/about/release-notes.hbs
@@ -19,6 +19,17 @@ meta-index: true
     </thead>
     <tbody>
       <tr>
+        <td>v3.24.10</td>
+        <td>17.06.26</td>
+        <td>
+          <h4>Patches</h4>
+          <ul>
+            <li>Updates to logo assets <a href="https://github.com/digitalnsw/nsw-design-system/pull/712" target="_blank" rel="noopener noreferrer">#712</a></li>
+          </ul>
+        </td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/digitalnsw/nsw-design-system/releases/tag/v3.24.10">Code kit</a></td>
+      </tr>
+      <tr>
         <td>v3.24.9</td>
         <td>15.05.26</td>
         <td>


### PR DESCRIPTION
This pull request adds a new entry to the release notes table to document version 3.24.10, including a summary of the patch and a link to the relevant code kit release.

Release notes update:

* Added a new row for version `v3.24.10` in the release notes, listing the patch "Updates to logo assets" with a link to pull request #712, and providing a link to the code kit for this release.