### PR TITLE
Reflow support - add helper for 400% zoom support

### DIFF
--- a/src/core/grid/_guidance.hbs
+++ b/src/core/grid/_guidance.hbs
@@ -3,7 +3,7 @@ title: Grid
 layout: blank-layout.hbs
 ---
 
-<p class="nsw-intro">The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 6 breakpoints. </p>
+<p class="nsw-intro">The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints. </p>
 
 <h2 class="nsw-h3">Breakpoints</h2>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
@@ -20,15 +20,8 @@ layout: blank-layout.hbs
       </thead>
       <tbody>
         <tr>
-          <td>xs (Extra Small)<br />0-319px</td>
+          <td>xs (Extra Small)<br />0-575px</td>
           <td><code>breakpoints-xs</code></td>
-          <td>16px</td>
-          <td>16px</td>
-          <td>288px</td>
-        </tr>
-        <tr>
-          <td>micro (Micro)<br />320-575px</td>
-          <td><code>breakpoints-micro</code></td>
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
@@ -66,10 +59,6 @@ layout: blank-layout.hbs
   </div>
 </div>
 
-<h2 class="nsw-h3">Micro breakpoint</h2>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits between <code>xs</code> and <code>sm</code> in the breakpoint sequence and supports compact component treatments for constrained viewports and 400% zoom states.</p>
-<p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
-
 <h2 class="nsw-h3">Container, columns and gutter</h2>
 <div class="nsw-p-x-md nsw-m-top-sm">
   <figure class="nsw-media">
@@ -83,7 +72,6 @@ layout: blank-layout.hbs
 <p>Grid gives you the flexibility with Flexbox to build responsive layouts across different breakpoints. For example, to increase cards from a 2 column layout on the md breakpoint to a 3 column layout on the lg breakpoint. The NSW Design System recommends the below number of columns per breakpoint to ensure the content is at an optimal layout for readability and accessibility: </p>
 <ul>
   <li>xs (Extra small) - 1 column</li>
-  <li>micro (Micro reflow threshold) - 1 column</li>
   <li>sm (Small) - up to 2 columns</li>
   <li>md (Medium) - up to 3 columns</li>
   <li>lg (Large) - up to 4 columns</li>
@@ -91,7 +79,7 @@ layout: blank-layout.hbs
 </ul>
 <p>You can find base grid components in the Figma UI Kit to enable quick building and prototyping. </p>
 <p> A set of rows make up a grid, and a set of columns make up a row. Columns are set using classes in this format: <code>nsw-col-{breakpoint}-{columns}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>columns</strong> is between <strong>1</strong> and <strong>12</strong>.</p>
 
 <h2 class="nsw-h3">Default grids</h2>
@@ -144,7 +132,7 @@ layout: blank-layout.hbs
 <h2 class="nsw-h3">Viewport Visibility</h2>
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information. </p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/core/grid/_guidance.hbs
+++ b/src/core/grid/_guidance.hbs
@@ -3,7 +3,7 @@ title: Grid
 layout: blank-layout.hbs
 ---
 
-<p class="nsw-intro">The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints. </p>
+<p class="nsw-intro">The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 6 breakpoints. </p>
 
 <h2 class="nsw-h3">Breakpoints</h2>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
@@ -25,6 +25,13 @@ layout: blank-layout.hbs
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
+        </tr>
+        <tr>
+          <td>micro (Micro)<br />320px reflow threshold</td>
+          <td><code>breakpoints-micro</code></td>
+          <td>16px</td>
+          <td>16px</td>
+          <td>288px</td>
         </tr>
         <tr>
           <td>sm (Small)<br />576-767px</td>
@@ -59,6 +66,10 @@ layout: blank-layout.hbs
   </div>
 </div>
 
+<h2 class="nsw-h3">Micro breakpoint</h2>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits within the existing <code>xs</code> range and supports compact component treatments for constrained viewports and 400% zoom states.</p>
+<p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
+
 <h2 class="nsw-h3">Container, columns and gutter</h2>
 <div class="nsw-p-x-md nsw-m-top-sm">
   <figure class="nsw-media">
@@ -72,6 +83,7 @@ layout: blank-layout.hbs
 <p>Grid gives you the flexibility with Flexbox to build responsive layouts across different breakpoints. For example, to increase cards from a 2 column layout on the md breakpoint to a 3 column layout on the lg breakpoint. The NSW Design System recommends the below number of columns per breakpoint to ensure the content is at an optimal layout for readability and accessibility: </p>
 <ul>
   <li>xs (Extra small) - 1 column</li>
+  <li>micro (Micro reflow threshold) - 1 column</li>
   <li>sm (Small) - up to 2 columns</li>
   <li>md (Medium) - up to 3 columns</li>
   <li>lg (Large) - up to 4 columns</li>
@@ -79,7 +91,7 @@ layout: blank-layout.hbs
 </ul>
 <p>You can find base grid components in the Figma UI Kit to enable quick building and prototyping. </p>
 <p> A set of rows make up a grid, and a set of columns make up a row. Columns are set using classes in this format: <code>nsw-col-{breakpoint}-{columns}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>columns</strong> is between <strong>1</strong> and <strong>12</strong>.</p>
 
 <h2 class="nsw-h3">Default grids</h2>
@@ -132,7 +144,7 @@ layout: blank-layout.hbs
 <h2 class="nsw-h3">Viewport Visibility</h2>
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information. </p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/core/grid/_guidance.hbs
+++ b/src/core/grid/_guidance.hbs
@@ -20,18 +20,18 @@ layout: blank-layout.hbs
       </thead>
       <tbody>
         <tr>
-          <td>xs (Extra Small)<br />0-575px</td>
+          <td>xs (Extra Small)<br />0-319px</td>
           <td><code>breakpoints-xs</code></td>
           <td>16px</td>
           <td>16px</td>
-          <td>544px</td>
+          <td>288px</td>
         </tr>
         <tr>
-          <td>micro (Micro)<br />320px reflow threshold</td>
+          <td>micro (Micro)<br />320-575px</td>
           <td><code>breakpoints-micro</code></td>
           <td>16px</td>
           <td>16px</td>
-          <td>288px</td>
+          <td>544px</td>
         </tr>
         <tr>
           <td>sm (Small)<br />576-767px</td>
@@ -67,7 +67,7 @@ layout: blank-layout.hbs
 </div>
 
 <h2 class="nsw-h3">Micro breakpoint</h2>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits within the existing <code>xs</code> range and supports compact component treatments for constrained viewports and 400% zoom states.</p>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits between <code>xs</code> and <code>sm</code> in the breakpoint sequence and supports compact component treatments for constrained viewports and 400% zoom states.</p>
 <p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
 
 <h2 class="nsw-h3">Container, columns and gutter</h2>

--- a/src/core/grid/index.hbs
+++ b/src/core/grid/index.hbs
@@ -14,13 +14,16 @@ meta-index: true
       <a href="#breakpoints">Breakpoints</a>
     </li>
     <li>
+      <a href="#micro-breakpoint">Micro breakpoint</a>
+    </li>
+    <li>
       <a href="#content-grids">Content grids</a>
     </li>
   </ul>
 </nav>
 
 <h2 id="breakpoints">Breakpoints</h2>
-<p>The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints.</p>
+<p>The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 6 breakpoints.</p>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
   <div class="nsw-table nsw-table--valign-middle">
     <table>
@@ -40,6 +43,13 @@ meta-index: true
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
+        </tr>
+        <tr>
+          <td>micro (Micro)<br/>320px reflow threshold</td>
+          <td><code>breakpoints-micro</code></td>
+          <td>16px</td>
+          <td>16px</td>
+          <td>288px</td>
         </tr>
         <tr>
           <td>sm (Small)<br/>576-767px</td>
@@ -75,10 +85,15 @@ meta-index: true
 </div>
 <br>
 
+<h3 id="micro-breakpoint">Micro breakpoint</h3>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits within the existing <code>xs</code> range and supports compact component treatments for constrained viewports and 400% zoom states.</p>
+<p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
+
 <h2 id="content-grids">Content grids</h2>
 <p>Grid gives you the flexibility with Flexbox to build responsive layouts across different breakpoints. For example, to increase cards from a 2 column layout on the md breakpoint to a 3 column layout on the lg breakpoint. The NSW Design System recommends the below number of columns per breakpoint to ensure the content is at an optimal layout for readability and accessibility: </p>
 <ul>
   <li>xs (Extra small) - 1 column</li>
+  <li>micro (Micro reflow threshold) - 1 column</li>
   <li>sm (Small) - up to 2 columns</li>
   <li>md (Medium) - up to 3 columns</li>
   <li>lg (Large) - up to 4 columns</li>
@@ -87,7 +102,7 @@ meta-index: true
 <p>You can find base grid components in the Figma UI Kit to enable quick building and prototyping. </p>
 <p> A set of rows make up a grid, and a set of columns make up a row. Columns are set using classes in this format:
   <code>nsw-col-{breakpoint}-{columns}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>columns</strong> is between <strong>1</strong> and <strong>12</strong>.</p>
 
 <h3>Grid layouts</h3>

--- a/src/core/grid/index.hbs
+++ b/src/core/grid/index.hbs
@@ -14,16 +14,13 @@ meta-index: true
       <a href="#breakpoints">Breakpoints</a>
     </li>
     <li>
-      <a href="#micro-breakpoint">Micro breakpoint</a>
-    </li>
-    <li>
       <a href="#content-grids">Content grids</a>
     </li>
   </ul>
 </nav>
 
 <h2 id="breakpoints">Breakpoints</h2>
-<p>The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 6 breakpoints.</p>
+<p>The NSW Design System is built on a 12 column responsive grid which adapts to the user’s viewport across 5 breakpoints.</p>
 <div class="nsw-section nsw-section--white nsw-block nsw-p-x-sm nsw-p-top-sm">
   <div class="nsw-table nsw-table--valign-middle">
     <table>
@@ -38,15 +35,8 @@ meta-index: true
       </thead>
       <tbody>
         <tr>
-          <td>xs (Extra Small)<br/>0-319px</td>
+          <td>xs (Extra Small)<br/>0-575px</td>
           <td><code>breakpoints-xs</code></td>
-          <td>16px</td>
-          <td>16px</td>
-          <td>288px</td>
-        </tr>
-        <tr>
-          <td>micro (Micro)<br/>320-575px</td>
-          <td><code>breakpoints-micro</code></td>
           <td>16px</td>
           <td>16px</td>
           <td>544px</td>
@@ -85,15 +75,10 @@ meta-index: true
 </div>
 <br>
 
-<h3 id="micro-breakpoint">Micro breakpoint</h3>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits between <code>xs</code> and <code>sm</code> in the breakpoint sequence and supports compact component treatments for constrained viewports and 400% zoom states.</p>
-<p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
-
 <h2 id="content-grids">Content grids</h2>
 <p>Grid gives you the flexibility with Flexbox to build responsive layouts across different breakpoints. For example, to increase cards from a 2 column layout on the md breakpoint to a 3 column layout on the lg breakpoint. The NSW Design System recommends the below number of columns per breakpoint to ensure the content is at an optimal layout for readability and accessibility: </p>
 <ul>
   <li>xs (Extra small) - 1 column</li>
-  <li>micro (Micro reflow threshold) - 1 column</li>
   <li>sm (Small) - up to 2 columns</li>
   <li>md (Medium) - up to 3 columns</li>
   <li>lg (Large) - up to 4 columns</li>
@@ -102,7 +87,7 @@ meta-index: true
 <p>You can find base grid components in the Figma UI Kit to enable quick building and prototyping. </p>
 <p> A set of rows make up a grid, and a set of columns make up a row. Columns are set using classes in this format:
   <code>nsw-col-{breakpoint}-{columns}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>columns</strong> is between <strong>1</strong> and <strong>12</strong>.</p>
 
 <h3>Grid layouts</h3>

--- a/src/core/grid/index.hbs
+++ b/src/core/grid/index.hbs
@@ -38,18 +38,18 @@ meta-index: true
       </thead>
       <tbody>
         <tr>
-          <td>xs (Extra Small)<br/>0-575px</td>
+          <td>xs (Extra Small)<br/>0-319px</td>
           <td><code>breakpoints-xs</code></td>
           <td>16px</td>
           <td>16px</td>
-          <td>544px</td>
+          <td>288px</td>
         </tr>
         <tr>
-          <td>micro (Micro)<br/>320px reflow threshold</td>
+          <td>micro (Micro)<br/>320-575px</td>
           <td><code>breakpoints-micro</code></td>
           <td>16px</td>
           <td>16px</td>
-          <td>288px</td>
+          <td>544px</td>
         </tr>
         <tr>
           <td>sm (Small)<br/>576-767px</td>
@@ -86,7 +86,7 @@ meta-index: true
 <br>
 
 <h3 id="micro-breakpoint">Micro breakpoint</h3>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits within the existing <code>xs</code> range and supports compact component treatments for constrained viewports and 400% zoom states.</p>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold. It sits between <code>xs</code> and <code>sm</code> in the breakpoint sequence and supports compact component treatments for constrained viewports and 400% zoom states.</p>
 <p>The existing <code>xs</code> breakpoint remains the base breakpoint from 0px. Use <code>micro</code> only where a component needs a specific adjustment at the WCAG reflow benchmark. In Sass, it may be used with <code>max-width</code> where styles need to apply at 320px and below.</p>
 
 <h2 id="content-grids">Content grids</h2>

--- a/src/docs/content/about/release-notes.hbs
+++ b/src/docs/content/about/release-notes.hbs
@@ -19,6 +19,21 @@ meta-index: true
     </thead>
     <tbody>
       <tr>
+        <td>v3.24.14</td>
+        <td>10.07.26</td>
+        <td>
+          <h4>Accessibility</h4>
+          <ul>
+            <li>Added a Reflow Sass helper for component-specific layout adjustments at the WCAG Reflow benchmark of 320 CSS pixels. This supports constrained viewports and 400% zoom states without changing the standard breakpoint scale <a href="https://github.com/digitalnsw/nsw-design-system/pull/730" target="_blank" rel="noopener noreferrer">#730</a></li>
+          </ul>
+          <h4>Docs &amp; Guidance</h4>
+          <ul>
+            <li>Added <a href="/docs/content/utilities/reflow.html">Reflow</a> guidance and search terms for WCAG Reflow, 400% zoom and 320 CSS pixel viewport support <a href="https://github.com/digitalnsw/nsw-design-system/pull/730" target="_blank" rel="noopener noreferrer">#730</a></li>
+          </ul>
+        </td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/digitalnsw/nsw-design-system/releases/tag/v3.24.14">Code kit</a></td>
+      </tr>
+      <tr>
         <td>v3.24.13</td>
         <td>07.07.26</td>
         <td>

--- a/src/docs/content/develop/getting-started.hbs
+++ b/src/docs/content/develop/getting-started.hbs
@@ -100,7 +100,7 @@ meta-index: true
 }
 {{/_docs-example}}
 
-<p>The <code>nsw.reflow</code> mixin targets the 320px WCAG Reflow threshold for constrained viewports and 400% zoom states. It is separate from the standard <code>$nsw-breakpoints</code> scale and does not generate grid, offset or visibility utility classes. Use it only where a component needs a specific adjustment at the WCAG Reflow benchmark. See <a href="/docs/content/utilities/reflow.html">Reflow</a> for guidance.</p>
+<p>The <code>nsw.reflow</code> mixin targets the WCAG Reflow benchmark of 320 CSS pixels for constrained viewports and 400% zoom states. It is separate from the standard <code>$nsw-breakpoints</code> scale and does not generate grid, offset or visibility utility classes. Use it only where a component needs a specific adjustment at the WCAG Reflow benchmark. See <a href="/docs/content/utilities/reflow.html">Reflow</a> for guidance.</p>
 <p><em>Performance note:</em> Importing the tools barrel does not add unused CSS. Mixins and functions only generate CSS when you call them, and the module is parsed once per build.</p>
 <p><strong>Tip:</strong> Prefer the barrel for consistency. If a file needs exactly one tool and you want explicit coupling, you can import that file directly (for example, <code>@use 'node_modules/nsw-design-system/src/global/scss/base/mixins' as mixins;</code>).</p>
 

--- a/src/docs/content/develop/getting-started.hbs
+++ b/src/docs/content/develop/getting-started.hbs
@@ -88,14 +88,19 @@ meta-index: true
 @use 'nsw-design-system/tools' as nsw;
 
 .example {
-  margin: nsw.rem(16);
+  padding: nsw.rem(16);
 
   @include nsw.breakpoint('md') {
-    margin: nsw.rem(32);
+    padding: nsw.rem(32);
+  }
+
+  @include nsw.reflow {
+    padding-inline: nsw.rem(8);
   }
 }
 {{/_docs-example}}
 
+<p>The <code>nsw.reflow</code> mixin targets the 320px WCAG Reflow threshold for constrained viewports and 400% zoom states. It is separate from the standard <code>$nsw-breakpoints</code> scale and does not generate grid, offset or visibility utility classes. Use it only where a component needs a specific adjustment at the WCAG Reflow benchmark.</p>
 <p><em>Performance note:</em> Importing the tools barrel does not add unused CSS. Mixins and functions only generate CSS when you call them, and the module is parsed once per build.</p>
 <p><strong>Tip:</strong> Prefer the barrel for consistency. If a file needs exactly one tool and you want explicit coupling, you can import that file directly (for example, <code>@use 'node_modules/nsw-design-system/src/global/scss/base/mixins' as mixins;</code>).</p>
 

--- a/src/docs/content/develop/getting-started.hbs
+++ b/src/docs/content/develop/getting-started.hbs
@@ -100,7 +100,7 @@ meta-index: true
 }
 {{/_docs-example}}
 
-<p>The <code>nsw.reflow</code> mixin targets the 320px WCAG Reflow threshold for constrained viewports and 400% zoom states. It is separate from the standard <code>$nsw-breakpoints</code> scale and does not generate grid, offset or visibility utility classes. Use it only where a component needs a specific adjustment at the WCAG Reflow benchmark.</p>
+<p>The <code>nsw.reflow</code> mixin targets the 320px WCAG Reflow threshold for constrained viewports and 400% zoom states. It is separate from the standard <code>$nsw-breakpoints</code> scale and does not generate grid, offset or visibility utility classes. Use it only where a component needs a specific adjustment at the WCAG Reflow benchmark. See <a href="/docs/content/utilities/reflow.html">Reflow</a> for guidance.</p>
 <p><em>Performance note:</em> Importing the tools barrel does not add unused CSS. Mixins and functions only generate CSS when you call them, and the module is parsed once per build.</p>
 <p><strong>Tip:</strong> Prefer the barrel for consistency. If a file needs exactly one tool and you want explicit coupling, you can import that file directly (for example, <code>@use 'node_modules/nsw-design-system/src/global/scss/base/mixins' as mixins;</code>).</p>
 

--- a/src/docs/content/utilities/reflow.hbs
+++ b/src/docs/content/utilities/reflow.hbs
@@ -1,0 +1,83 @@
+---
+title: Reflow
+width: narrow
+intro: Use the reflow Sass helper to apply component-specific layout adjustments at the WCAG Reflow threshold.
+no-blank: true
+meta-description: Use the NSW Design System reflow Sass helper for component-specific layout adjustments at the 320px WCAG Reflow threshold and 400% zoom states.
+meta-index: true
+---
+
+<p>The <code>nsw.reflow</code> mixin applies styles at the 320 CSS pixel WCAG Reflow threshold. This helps components remain usable when a page is viewed in constrained viewports, including common 400% zoom test states.</p>
+
+<p>WCAG 2.1 <a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html" target="_blank" rel="noopener noreferrer">Success Criterion 1.4.10: Reflow</a> requires content to be presented without loss of information or functionality, and without two-dimensional scrolling, at a width equivalent to 320 CSS pixels. The W3C understanding document explains that 320 CSS pixels is equivalent to a 1280 CSS pixel wide viewport at 400% zoom.</p>
+
+<h3>How it relates to breakpoints</h3>
+
+<p>Reflow support sits on top of the standard responsive breakpoint system. It is separate from the standard <code>$nsw-breakpoints</code> scale used by grid, offset and visibility utilities.</p>
+
+<p>The standard breakpoint scale remains:</p>
+
+{{#>_docs-example hidden="true" open="true" code="scss"}}
+$nsw-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+);
+{{/_docs-example}}
+
+<p>The <code>xs</code> breakpoint remains the base breakpoint from <code>0</code>. The reflow helper is an additional constraint layer that can override or refine component styles at <code>320px</code> and below when the normal <code>xs</code> treatment is not enough.</p>
+
+<p>Because reflow is separate from <code>$nsw-breakpoints</code>, it does not generate public grid, offset, display or visibility utilities such as <code>.nsw-col-reflow-*</code>, <code>.nsw-offset-reflow-*</code>, <code>.nsw-show-reflow</code> or <code>.nsw-hide-reflow</code>.</p>
+
+<h3>Using the helper</h3>
+
+<p>Import the tools barrel and include <code>nsw.reflow</code> inside the component that needs a specific compact treatment.</p>
+
+{{#>_docs-example hidden="true" open="true" code="scss"}}
+@use 'nsw-design-system/tools' as nsw;
+
+.example-component {
+  display: flex;
+  gap: nsw.rem(16px);
+
+  @include nsw.reflow {
+    gap: nsw.rem(8px);
+  }
+}
+{{/_docs-example}}
+
+<p>By default, this compiles to a <code>max-width</code> media query using the reflow threshold:</p>
+
+{{#>_docs-example hidden="true" open="true" code="css"}}
+@media (max-width: 20rem) {
+  .example-component {
+    gap: 0.5rem;
+  }
+}
+{{/_docs-example}}
+
+<p>The threshold is exposed as a Sass setting:</p>
+
+{{#>_docs-example hidden="true" open="true" code="scss"}}
+$nsw-reflow-threshold: 320px !default;
+{{/_docs-example}}
+
+<p>Use <code>nsw.reflow</code> for component-specific changes that make the component work at the WCAG reflow benchmark. For example, reducing dense spacing, simplifying persistent controls, resizing icons, changing wrapping behaviour, or adjusting a sticky component that takes too much space at 400% zoom.</p>
+
+<h3>When to use it</h3>
+
+<p>Use the reflow helper when a component has a real layout or usability problem at the 320px reflow threshold and the standard <code>xs</code> styles are too broad. Reflow styles should be targeted and minimal.</p>
+
+<ul>
+  <li>Use standard grid and breakpoint utilities for normal responsive layouts.</li>
+  <li>Use <code>nsw.reflow</code> only for the 320px WCAG Reflow threshold.</li>
+  <li>Keep reflow styles close to the component they adjust.</li>
+  <li>Check that content remains available and functional without requiring page-level horizontal scrolling.</li>
+  <li>Retest the component at 400% browser zoom or an equivalent 320 CSS pixel viewport.</li>
+</ul>
+
+<h3>Exceptions</h3>
+
+<p>Some content needs two-dimensional layout for meaning or operation, such as data tables, maps, diagrams, video, games or interfaces where a toolbar must remain in view. These cases still need careful handling so the rest of the page can reflow and any horizontal scrolling is limited to the specific content that needs it.</p>

--- a/src/docs/content/utilities/reflow.hbs
+++ b/src/docs/content/utilities/reflow.hbs
@@ -7,11 +7,22 @@ meta-description: Use the NSW Design System Reflow helper for component-specific
 meta-index: true
 ---
 
+<nav class="nsw-in-page-nav" aria-labelledby="in-page-nav">
+  <div id="in-page-nav" class="nsw-in-page-nav__title">On this page</div>
+  <ul class="nsw-in-page-nav__list">
+    <li><a href="#how-it-relates-to-breakpoints">How it relates to breakpoints</a></li>
+    <li><a href="#using-the-helper">Using the helper</a></li>
+    <li><a href="#without-sass">Without Sass</a></li>
+    <li><a href="#when-to-use-it">When to use it</a></li>
+    <li><a href="#exceptions">Exceptions</a></li>
+  </ul>
+</nav>
+
 <p>The <code>nsw.reflow</code> mixin applies styles at the WCAG Reflow benchmark of 320 CSS pixels. This helps components remain usable when a page is viewed in constrained viewports, including common 400% zoom test states.</p>
 
 <p>WCAG 2.1 <a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html" target="_blank" rel="noopener noreferrer">Success Criterion 1.4.10: Reflow</a> requires content to be presented without loss of information or functionality, and without two-dimensional scrolling, at a width equivalent to 320 CSS pixels. The W3C understanding document explains that 320 CSS pixels is equivalent to a 1280 CSS pixel wide viewport at 400% zoom.</p>
 
-<h3>How it relates to breakpoints</h3>
+<h2 id="how-it-relates-to-breakpoints">How it relates to breakpoints</h2>
 
 <p>Reflow support sits on top of the standard responsive breakpoint system. It is separate from the standard <code>$nsw-breakpoints</code> scale used by grid, offset and visibility utilities.</p>
 
@@ -31,7 +42,7 @@ $nsw-breakpoints: (
 
 <p>Because reflow is separate from <code>$nsw-breakpoints</code>, it does not generate public grid, offset, display or visibility utilities such as <code>.nsw-col-reflow-*</code>, <code>.nsw-offset-reflow-*</code>, <code>.nsw-show-reflow</code> or <code>.nsw-hide-reflow</code>.</p>
 
-<h3>Using the helper</h3>
+<h2 id="using-the-helper">Using the helper</h2>
 
 <p>Import the tools barrel and include <code>nsw.reflow</code> inside the component that needs a specific compact treatment.</p>
 
@@ -64,7 +75,7 @@ $nsw-breakpoints: (
 $nsw-reflow-threshold: 320px !default;
 {{/_docs-example}}
 
-<h3>Without Sass</h3>
+<h2 id="without-sass">Without Sass</h2>
 
 <p>If you use the compiled NSW Design System CSS, any Reflow styles shipped with a NSW component are already included. You do not need Sass to receive those shipped component styles.</p>
 
@@ -84,7 +95,7 @@ $nsw-reflow-threshold: 320px !default;
 
 <p>Use <code>nsw.reflow</code> for component-specific changes that make the component work at the WCAG reflow benchmark. For example, reducing dense spacing, simplifying persistent controls, resizing icons, changing wrapping behaviour, or adjusting a sticky component that takes too much space at 400% zoom.</p>
 
-<h3>When to use it</h3>
+<h2 id="when-to-use-it">When to use it</h2>
 
 <p>Use the Reflow helper when a component has a real layout or usability problem at the WCAG Reflow benchmark and the standard <code>xs</code> styles are too broad. Reflow styles should be targeted and minimal.</p>
 
@@ -96,6 +107,6 @@ $nsw-reflow-threshold: 320px !default;
   <li>Retest the component at 400% browser zoom or an equivalent 320 CSS pixel viewport.</li>
 </ul>
 
-<h3>Exceptions</h3>
+<h2 id="exceptions">Exceptions</h2>
 
-<p>Some content needs two-dimensional layout for meaning or operation, such as data tables, maps, diagrams, video, games or interfaces where a toolbar must remain in view. These cases still need careful handling so the rest of the page can reflow and any horizontal scrolling is limited to the specific content that needs it.</p>
+<p>Some content needs two-dimensional layout for meaning or operation, such as data tables, maps, diagrams, video or interfaces where a toolbar must remain in view. These cases still need careful handling so the rest of the page can reflow and any horizontal scrolling is limited to the specific content that needs it.</p>

--- a/src/docs/content/utilities/reflow.hbs
+++ b/src/docs/content/utilities/reflow.hbs
@@ -1,13 +1,13 @@
 ---
 title: Reflow
 width: narrow
-intro: Use the reflow Sass helper to apply component-specific layout adjustments at the WCAG Reflow threshold.
+intro: Use the Reflow Sass helper to apply component-specific layout adjustments at the WCAG Reflow benchmark.
 no-blank: true
-meta-description: Use the NSW Design System reflow Sass helper for component-specific layout adjustments at the 320px WCAG Reflow threshold and 400% zoom states.
+meta-description: Use the NSW Design System Reflow helper for component-specific layout adjustments at the WCAG Reflow benchmark of 320 CSS pixels and 400% zoom states.
 meta-index: true
 ---
 
-<p>The <code>nsw.reflow</code> mixin applies styles at the 320 CSS pixel WCAG Reflow threshold. This helps components remain usable when a page is viewed in constrained viewports, including common 400% zoom test states.</p>
+<p>The <code>nsw.reflow</code> mixin applies styles at the WCAG Reflow benchmark of 320 CSS pixels. This helps components remain usable when a page is viewed in constrained viewports, including common 400% zoom test states.</p>
 
 <p>WCAG 2.1 <a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html" target="_blank" rel="noopener noreferrer">Success Criterion 1.4.10: Reflow</a> requires content to be presented without loss of information or functionality, and without two-dimensional scrolling, at a width equivalent to 320 CSS pixels. The W3C understanding document explains that 320 CSS pixels is equivalent to a 1280 CSS pixel wide viewport at 400% zoom.</p>
 
@@ -27,7 +27,7 @@ $nsw-breakpoints: (
 );
 {{/_docs-example}}
 
-<p>The <code>xs</code> breakpoint remains the base breakpoint from <code>0</code>. The reflow helper is an additional constraint layer that can override or refine component styles at <code>320px</code> and below when the normal <code>xs</code> treatment is not enough.</p>
+<p>The <code>xs</code> breakpoint remains the base breakpoint from <code>0</code>. The Reflow helper is an additional constraint layer that can override or refine component styles at <code>320px</code> and below when the normal <code>xs</code> treatment is not enough.</p>
 
 <p>Because reflow is separate from <code>$nsw-breakpoints</code>, it does not generate public grid, offset, display or visibility utilities such as <code>.nsw-col-reflow-*</code>, <code>.nsw-offset-reflow-*</code>, <code>.nsw-show-reflow</code> or <code>.nsw-hide-reflow</code>.</p>
 
@@ -64,15 +64,33 @@ $nsw-breakpoints: (
 $nsw-reflow-threshold: 320px !default;
 {{/_docs-example}}
 
+<h3>Without Sass</h3>
+
+<p>If you use the compiled NSW Design System CSS, any Reflow styles shipped with a NSW component are already included. You do not need Sass to receive those shipped component styles.</p>
+
+<p>Not every component will need, or currently include, a Reflow adjustment. Test the component at 400% browser zoom or an equivalent 320 CSS pixel viewport, then add targeted CSS only where the component has a real layout or usability issue.</p>
+
+<p>If you are writing custom CSS without Sass, use the compiled media query directly:</p>
+
+{{#>_docs-example hidden="true" open="true" code="css"}}
+@media (max-width: 20rem) {
+  .example-component {
+    gap: 0.5rem;
+  }
+}
+{{/_docs-example}}
+
+<p><code>20rem</code> is the compiled equivalent of the 320 CSS pixel Reflow threshold. Use it for targeted component adjustments only, not as a replacement for the standard breakpoint scale.</p>
+
 <p>Use <code>nsw.reflow</code> for component-specific changes that make the component work at the WCAG reflow benchmark. For example, reducing dense spacing, simplifying persistent controls, resizing icons, changing wrapping behaviour, or adjusting a sticky component that takes too much space at 400% zoom.</p>
 
 <h3>When to use it</h3>
 
-<p>Use the reflow helper when a component has a real layout or usability problem at the 320px reflow threshold and the standard <code>xs</code> styles are too broad. Reflow styles should be targeted and minimal.</p>
+<p>Use the Reflow helper when a component has a real layout or usability problem at the WCAG Reflow benchmark and the standard <code>xs</code> styles are too broad. Reflow styles should be targeted and minimal.</p>
 
 <ul>
   <li>Use standard grid and breakpoint utilities for normal responsive layouts.</li>
-  <li>Use <code>nsw.reflow</code> only for the 320px WCAG Reflow threshold.</li>
+  <li>Use <code>nsw.reflow</code> only for the WCAG Reflow benchmark of 320 CSS pixels.</li>
   <li>Keep reflow styles close to the component they adjust.</li>
   <li>Check that content remains available and functional without requiring page-level horizontal scrolling.</li>
   <li>Retest the component at 400% browser zoom or an equivalent 320 CSS pixel viewport.</li>

--- a/src/docs/content/utilities/visibility.hbs
+++ b/src/docs/content/utilities/visibility.hbs
@@ -10,8 +10,7 @@ meta-index: true
 
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information.</p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold between <code>xs</code> and <code>sm</code>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/docs/content/utilities/visibility.hbs
+++ b/src/docs/content/utilities/visibility.hbs
@@ -11,7 +11,7 @@ meta-index: true
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information.</p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
 <p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
-<p>Visibility utilities use the standard breakpoint scale only. For component-specific layout adjustments at the 320px WCAG Reflow threshold or 400% zoom states, use the <a href="/docs/content/utilities/reflow.html">Reflow</a> Sass helper.</p>
+<p>Visibility utilities use the standard breakpoint scale only. For component-specific layout adjustments at the WCAG Reflow benchmark of 320 CSS pixels or 400% zoom states, use the <a href="/docs/content/utilities/reflow.html">Reflow</a> Sass helper.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/docs/content/utilities/visibility.hbs
+++ b/src/docs/content/utilities/visibility.hbs
@@ -11,6 +11,7 @@ meta-index: true
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information.</p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
 <p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
+<p>Visibility utilities use the standard breakpoint scale only. For component-specific layout adjustments at the 320px WCAG Reflow threshold or 400% zoom states, use the <a href="/docs/content/utilities/reflow.html">Reflow</a> Sass helper.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/docs/content/utilities/visibility.hbs
+++ b/src/docs/content/utilities/visibility.hbs
@@ -10,7 +10,8 @@ meta-index: true
 
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information.</p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
-<p>Where <strong>breakpoint</strong> is one of <strong>xs, sm, md, lg, xl</strong>.</p>
+<p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold within the existing <code>xs</code> range.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/docs/content/utilities/visibility.hbs
+++ b/src/docs/content/utilities/visibility.hbs
@@ -11,7 +11,7 @@ meta-index: true
 <p>Grid classes give you the option to show or hide elements in certain breakpoints. For example, displaying an image on a large screen when it supports the content, but hiding it on a small screen when it hinders the users access to information.</p>
 <p>The classes are named using the format <code>nsw-{display}-{breakpoint}</code></p>
 <p>Where <strong>breakpoint</strong> is one of <strong>xs, micro, sm, md, lg, xl</strong>.</p>
-<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold within the existing <code>xs</code> range.</p>
+<p>The <code>micro</code> breakpoint marks the 320px WCAG Reflow threshold between <code>xs</code> and <code>sm</code>.</p>
 <p>Where <strong>display</strong> is one of:</p>
 <ul>
   <li><strong>show</strong> - displays the elements</li>

--- a/src/docs/data.js
+++ b/src/docs/data.js
@@ -404,7 +404,7 @@ const searchValues = [
   {
     label: 'Reflow',
     template: 'result',
-    keywords: 'reflow, WCAG reflow, WCAG 1.4.10, Success Criterion 1.4.10, 400% zoom, 400 percent zoom, 320px, 320 CSS pixels, 1280px at 400%, responsive, accessibility, zoom, low vision, constrained viewport, horizontal scrolling, two-dimensional scrolling, max-width 20rem, nsw.reflow, $nsw-reflow-threshold, Sass helper, breakpoint, breakpoints',
+    keywords: 'reflow, WCAG reflow, WCAG 1.4.10, Success Criterion 1.4.10, 400% zoom, 400 percent zoom, 320px, 320 CSS pixels, 1280px at 400%, responsive, accessibility, zoom, low vision, constrained viewport, horizontal scrolling, two-dimensional scrolling, max-width 20rem, nsw.reflow, $nsw-reflow-threshold, Sass helper, CSS, compiled CSS, without Sass, no Sass, media query, breakpoint, breakpoints',
     url: '/docs/content/utilities/reflow.html',
   },
   {

--- a/src/docs/data.js
+++ b/src/docs/data.js
@@ -158,7 +158,7 @@ const searchValues = [
   {
     label: 'Quick exit',
     template: 'result',
-    keywords: 'safety, privacy, discreet, exit now, quick exit, safe destination, safe url, emergency exit, panic button, escape key, esc, double esc, keyboard, sticky, global sticky container, 400% zoom, WCAG reflow',
+    keywords: 'safety, privacy, discreet, exit now, quick exit, safe destination, safe url, emergency exit, panic button, escape key, esc, double esc, keyboard, sticky, global sticky container',
     url: '/components/quick-exit/index.html',
   },
   {

--- a/src/docs/data.js
+++ b/src/docs/data.js
@@ -158,7 +158,7 @@ const searchValues = [
   {
     label: 'Quick exit',
     template: 'result',
-    keywords: 'safety, privacy, discreet, exit now, quick exit, safe destination, safe url, emergency exit, panic button, escape key, esc, double esc, keyboard, sticky, global sticky container',
+    keywords: 'safety, privacy, discreet, exit now, quick exit, safe destination, safe url, emergency exit, panic button, escape key, esc, double esc, keyboard, sticky, global sticky container, 400% zoom, WCAG reflow',
     url: '/components/quick-exit/index.html',
   },
   {
@@ -400,6 +400,12 @@ const searchValues = [
     template: 'result',
     keywords: 'Position, static, relative, absolute, fixed, sticky',
     url: '/docs/content/utilities/position.html',
+  },
+  {
+    label: 'Reflow',
+    template: 'result',
+    keywords: 'reflow, WCAG reflow, WCAG 1.4.10, Success Criterion 1.4.10, 400% zoom, 400 percent zoom, 320px, 320 CSS pixels, 1280px at 400%, responsive, accessibility, zoom, low vision, constrained viewport, horizontal scrolling, two-dimensional scrolling, max-width 20rem, nsw.reflow, $nsw-reflow-threshold, Sass helper, breakpoint, breakpoints',
+    url: '/docs/content/utilities/reflow.html',
   },
   {
     label: 'Spacing',

--- a/src/global/scss/base/_mixins.scss
+++ b/src/global/scss/base/_mixins.scss
@@ -22,6 +22,12 @@
   }
 }
 
+@mixin reflow($width-type: max-width) {
+  @media ($width-type: functions.rem(settings.$nsw-reflow-width)) {
+    @content;
+  }
+}
+
 @mixin prefers-reduced-motion() {
   @media (prefers-reduced-motion: reduce) {
     @content;

--- a/src/global/scss/base/_mixins.scss
+++ b/src/global/scss/base/_mixins.scss
@@ -10,8 +10,8 @@
     @error 'NSW-DS Breakpoint mixin accepts only strings';
   }
 
-  @if $size != 'xs' and $size != 'sm' and $size != 'md' and $size != 'lg' and $size != 'xl' {
-    @error 'NSW-DS Breakpoint mixin allows the following breakpoint sizes xs, sm, md, lg';
+  @if not map.has-key(settings.$nsw-breakpoints, $size) {
+    @error 'NSW-DS Breakpoint mixin allows the following breakpoint sizes #{map.keys(settings.$nsw-breakpoints)}';
   } @else {
     $px-size: map.get(settings.$nsw-breakpoints, $size);
     $rem-size: functions.rem($px-size);

--- a/src/global/scss/base/_mixins.scss
+++ b/src/global/scss/base/_mixins.scss
@@ -23,7 +23,7 @@
 }
 
 @mixin reflow($width-type: max-width) {
-  @media ($width-type: functions.rem(settings.$nsw-reflow-width)) {
+  @media ($width-type: functions.rem(settings.$nsw-reflow-threshold)) {
     @content;
   }
 }

--- a/src/global/scss/settings/_settings.scss
+++ b/src/global/scss/settings/_settings.scss
@@ -13,7 +13,7 @@ $nsw-breakpoints: (
 ) !default;
 
 // WCAG Reflow threshold used by the reflow mixin. Keep separate from the public breakpoint scale.
-$nsw-reflow-width: 320px !default;
+$nsw-reflow-threshold: 320px !default;
 
 //Breakpoint to switch to desktop view (Layout and Navigation)
 $nsw-desktop-breakpoint: lg;

--- a/src/global/scss/settings/_settings.scss
+++ b/src/global/scss/settings/_settings.scss
@@ -6,12 +6,14 @@ $enable-important-utilities: true !default;
 // Breakpoints
 $nsw-breakpoints: (
   xs: 0,
-  micro: 320px,
   sm: 576px,
   md: 768px,
   lg: 992px,
   xl: 1200px,
 ) !default;
+
+// WCAG Reflow threshold used by the reflow mixin. Keep separate from the public breakpoint scale.
+$nsw-reflow-width: 320px !default;
 
 //Breakpoint to switch to desktop view (Layout and Navigation)
 $nsw-desktop-breakpoint: lg;

--- a/src/global/scss/settings/_settings.scss
+++ b/src/global/scss/settings/_settings.scss
@@ -12,7 +12,7 @@ $nsw-breakpoints: (
   xl: 1200px,
 ) !default;
 
-// WCAG Reflow threshold used by the reflow mixin. Keep separate from the public breakpoint scale.
+// Reflow threshold for the WCAG benchmark. Keep separate from the public breakpoint scale.
 $nsw-reflow-threshold: 320px !default;
 
 //Breakpoint to switch to desktop view (Layout and Navigation)

--- a/src/global/scss/settings/_settings.scss
+++ b/src/global/scss/settings/_settings.scss
@@ -6,6 +6,7 @@ $enable-important-utilities: true !default;
 // Breakpoints
 $nsw-breakpoints: (
   xs: 0,
+  micro: 320px,
   sm: 576px,
   md: 768px,
   lg: 992px,


### PR DESCRIPTION
This pull request adds dedicated Reflow support for constrained viewports and 400% zoom states without changing the public NSW Design System breakpoint scale.

The standard breakpoint map remains unchanged:

```scss
$nsw-breakpoints: (
  xs: 0,
  sm: 576px,
  md: 768px,
  lg: 992px,
  xl: 1200px,
);
```

The Reflow threshold and mixin sit outside the standard breakpoint map:

```scss
$nsw-reflow-threshold: 320px !default;

@mixin reflow($width-type: max-width) {
  @media ($width-type: functions.rem(settings.$nsw-reflow-threshold)) {
    @content;
  }
}
```

Usage:

```scss
@include nsw.reflow {
  // compact component treatment for 320px and below
}
```

## What changed

- Adds `$nsw-reflow-threshold: 320px !default` as a Reflow threshold for the WCAG benchmark outside `$nsw-breakpoints`.
- Adds `@include nsw.reflow` for component-level compact treatments at 320px and below.
- Keeps `xs` as the base breakpoint from `0` and leaves the standard breakpoint scale unchanged.
- Documents `nsw.reflow` as a Sass helper for the WCAG Reflow benchmark of 320 CSS pixels and 400% zoom states.
- Adds search terms and utility documentation for Reflow guidance.

## Public API impact

The standard breakpoint map remains unchanged. Grid, offset, display and visibility utilities continue to be generated from the existing breakpoint scale only.

The Reflow helper is an additional accessibility/layout constraint layer for components that need explicit treatment at the WCAG Reflow benchmark.