### PR TITLE
Docs - prioritise use of red

### DIFF
--- a/src/components/hero-banner/blank.hbs
+++ b/src/components/hero-banner/blank.hbs
@@ -5,11 +5,27 @@ page: true
 
 {{>_hero-banner
   wide=true
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+
+{{>_hero-banner
+  wide=true
+  theme="off-white"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+
+{{>_hero-banner
+  wide=true
   theme="dark"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
   wide=true
   theme="light"
@@ -17,17 +33,21 @@ page: true
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
-  wide=true
+  wide=false
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
-  wide=true
+  wide=false
   theme="off-white"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
@@ -39,6 +59,7 @@ page: true
   img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
   wide=false
   theme="light"
@@ -47,19 +68,21 @@ page: true
   img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
-  wide=false
+  wide=true
+  lines=true
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
-  wide=false
+  wide=true
   theme="off-white"
+  lines=true
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
@@ -71,6 +94,7 @@ page: true
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
   wide=true
   lines=true
@@ -79,20 +103,22 @@ page: true
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
 }}
+
 {{>_hero-banner
-  wide=true
-  lines=true
+  wide=false
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
 }}
+
 {{>_hero-banner
-  wide=true
+  wide=false
   theme="off-white"
-  lines=true
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
 }}
 
 {{>_hero-banner
@@ -103,24 +129,10 @@ page: true
   links-title="Key coronavirus links"
   links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
 }}
+
 {{>_hero-banner
   wide=false
   theme="light"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-{{>_hero-banner
-  wide=false
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-{{>_hero-banner
-  wide=false
-  theme="off-white"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   links-title="Key coronavirus links"

--- a/src/components/hero-banner/index.hbs
+++ b/src/components/hero-banner/index.hbs
@@ -12,11 +12,32 @@ meta-index: true
 <h3>Primary message</h3>
 <div class="nsw-tabs js-tabs">
   <ul class="nsw-tabs__list">
-    <li><a href="#primary-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
-    <li><a href="#primary-brand-light" class="js-tabs-fixed">Brand Light</a></li>
     <li><a href="#primary-white" class="js-tabs-fixed">White</a></li>
     <li><a href="#primary-off-white" class="js-tabs-fixed">Off-White</a></li>
+    <li><a href="#primary-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
+    <li><a href="#primary-brand-light" class="js-tabs-fixed">Brand Light</a></li>
   </ul>
+  <section id="primary-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=true
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
+  <section id="primary-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=true
+  theme="off-white"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
   <section id="primary-brand-dark" class="nsw-tabs__content nsw-tabs__content--side-flush">
 {{#>_docs-example}}
 {{>_hero-banner
@@ -39,37 +60,39 @@ meta-index: true
 }}
 {{/_docs-example}}
   </section>
-  <section id="primary-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=true
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
-  <section id="primary-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=true
-  theme="off-white"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
 </div>
 
 <h3>Supporting image</h3>
 <div class="nsw-tabs js-tabs">
   <ul class="nsw-tabs__list">
-    <li><a href="#image-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
-    <li><a href="#image-brand-light" class="js-tabs-fixed">Brand Light</a></li>
     <li><a href="#image-white" class="js-tabs-fixed">White</a></li>
     <li><a href="#image-off-white" class="js-tabs-fixed">Off-White</a></li>
+    <li><a href="#image-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
+    <li><a href="#image-brand-light" class="js-tabs-fixed">Brand Light</a></li>
   </ul>
+  <section id="image-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=false
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
+  <section id="image-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=false
+  theme="off-white"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
   <section id="image-brand-dark" class="nsw-tabs__content nsw-tabs__content--side-flush">
 {{#>_docs-example}}
 {{>_hero-banner
@@ -94,39 +117,39 @@ meta-index: true
 }}
 {{/_docs-example}}
   </section>
-  <section id="image-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=false
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
-  <section id="image-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=false
-  theme="off-white"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
 </div>
 
 <h3>Supporting line system</h3>
 <div class="nsw-tabs js-tabs">
   <ul class="nsw-tabs__list">
-    <li><a href="#line-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
-    <li><a href="#line-brand-light" class="js-tabs-fixed">Brand Light</a></li>
     <li><a href="#line-white" class="js-tabs-fixed">White</a></li>
     <li><a href="#line-off-white" class="js-tabs-fixed">Off-White</a></li>
+    <li><a href="#line-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
+    <li><a href="#line-brand-light" class="js-tabs-fixed">Brand Light</a></li>
   </ul>
+  <section id="line-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=true
+  lines=true
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
+  <section id="line-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=true
+  theme="off-white"
+  lines=true
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+{{/_docs-example}}
+  </section>
   <section id="line-brand-dark" class="nsw-tabs__content nsw-tabs__content--side-flush">
 {{#>_docs-example}}
 {{>_hero-banner
@@ -151,39 +174,39 @@ meta-index: true
 }}
 {{/_docs-example}}
   </section>
-  <section id="line-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=true
-  lines=true
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
-  <section id="line-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=true
-  theme="off-white"
-  lines=true
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-{{/_docs-example}}
-  </section>
 </div>
 
 <h3>Supporting content</h3>
 <div class="nsw-tabs js-tabs">
   <ul class="nsw-tabs__list">
-    <li><a href="#content-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
-    <li><a href="#content-brand-light" class="js-tabs-fixed">Brand Light</a></li>
     <li><a href="#content-white" class="js-tabs-fixed">White</a></li>
     <li><a href="#content-off-white" class="js-tabs-fixed">Off-White</a></li>
+    <li><a href="#content-brand-dark" class="js-tabs-fixed">Brand Dark</a></li>
+    <li><a href="#content-brand-light" class="js-tabs-fixed">Brand Light</a></li>
   </ul>
+  <section id="content-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=false
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
+}}
+{{/_docs-example}}
+  </section>
+  <section id="content-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
+{{#>_docs-example}}
+{{>_hero-banner
+  wide=false
+  theme="off-white"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
+}}
+{{/_docs-example}}
+  </section>
   <section id="content-brand-dark" class="nsw-tabs__content nsw-tabs__content--side-flush">
 {{#>_docs-example}}
 {{>_hero-banner
@@ -201,29 +224,6 @@ meta-index: true
 {{>_hero-banner
   wide=false
   theme="light"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-{{/_docs-example}}
-  </section>
-  <section id="content-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=false
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-{{/_docs-example}}
-  </section>
-  <section id="content-off-white"  class="nsw-tabs__content nsw-tabs__content--side-flush">
-{{#>_docs-example}}
-{{>_hero-banner
-  wide=false
-  theme="off-white"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   links-title="Key coronavirus links"

--- a/src/components/hero-banner/theme.hbs
+++ b/src/components/hero-banner/theme.hbs
@@ -6,22 +6,6 @@ page: true
 {{#>_theme}}
 {{>_hero-banner
   wide=true
-  theme="dark"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-
-{{>_hero-banner
-  wide=true
-  theme="light"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  cta="View Digital Service Toolkit"
-}}
-
-{{>_hero-banner
-  wide=true
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
@@ -36,20 +20,18 @@ page: true
 }}
 
 {{>_hero-banner
-  wide=false
+  wide=true
   theme="dark"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
 {{>_hero-banner
-  wide=false
+  wide=true
   theme="light"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
@@ -71,20 +53,20 @@ page: true
 }}
 
 {{>_hero-banner
-  wide=true
-  lines=true
+  wide=false
   theme="dark"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
 {{>_hero-banner
-  wide=true
-  lines=true
+  wide=false
   theme="light"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  img="https://picsum.photos/id/237/2000/1250"
   cta="View Digital Service Toolkit"
 }}
 
@@ -103,6 +85,41 @@ page: true
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   cta="View Digital Service Toolkit"
+}}
+
+{{>_hero-banner
+  wide=true
+  lines=true
+  theme="dark"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+
+{{>_hero-banner
+  wide=true
+  lines=true
+  theme="light"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  cta="View Digital Service Toolkit"
+}}
+
+{{>_hero-banner
+  wide=false
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
+}}
+
+{{>_hero-banner
+  wide=false
+  theme="off-white"
+  heading="Helping you deliver great government services"
+  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
+  links-title="Key coronavirus links"
+  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
 }}
 
 {{>_hero-banner
@@ -117,23 +134,6 @@ page: true
 {{>_hero-banner
   wide=false
   theme="light"
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-
-{{>_hero-banner
-  wide=false
-  heading="Helping you deliver great government services"
-  copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
-  links-title="Key coronavirus links"
-  links=(split "COVIDSafe App;Current COVID-19 case locations;Travel to and from NSW;Health and wellbeing;Business and work;COVID-19 testing centres")
-}}
-
-{{>_hero-banner
-  wide=false
-  theme="off-white"
   heading="Helping you deliver great government services"
   copy="Find the building blocks for creating user-centred digital services, as well as policy, tools and guidance"
   links-title="Key coronavirus links"


### PR DESCRIPTION
### Motivation
- Ensure the first demo example for hero banners presents a neutral (White) background before Off-White and brand variants so the blue brand colours are not the initial visual option.

### Description
- Reordered tab labels and the corresponding tab panels in `src/components/hero-banner/index.hbs` so each group shows `White`, `Off-White`, `Brand Dark`, then `Brand Light`.
- Applied the same neutral-first ordering to the full-page examples in `src/components/hero-banner/theme.hbs` and `src/components/hero-banner/blank.hbs`, updating the `theme` attributes where needed.
- Changes are strictly to demo/documentation ordering and example data; no component implementation or styles were modified. Modified files: `src/components/hero-banner/index.hbs`, `src/components/hero-banner/theme.hbs`, `src/components/hero-banner/blank.hbs`.

### Testing
- `npm run prod:build` — succeeded.
- Python assertion that inspected the generated `dist` HTML to confirm each hero-banner tab group now uses `White → Off-White → Brand Dark → Brand Light` — succeeded.
- `git diff --check` to validate whitespace and diff issues — succeeded.
- `npx playwright install chromium` (attempted to capture screenshots) — failed due to browser download endpoints returning HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712f527a408332a1bdd1b54a18cf75)