### PR TITLE
Sets Secure and SameSite attributes on global alert dismissal cookie

### DIFF
--- a/src/components/global-alert/global-alert.js
+++ b/src/components/global-alert/global-alert.js
@@ -32,7 +32,8 @@ class GlobalAlert {
     const date = new Date()
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000))
     const expires = `expires=${date.toUTCString()}`
-    document.cookie = `${name}=${value};${expires};path=/`
+    const secure = window.location.protocol === 'https:' ? ';Secure' : ''
+    document.cookie = `${name}=${value};${expires};path=/;SameSite=Lax${secure}`
   }
 
   static getCookie(name) {


### PR DESCRIPTION
Closes #743.

## What changed

`GlobalAlert.setCookie()` now sets `SameSite=Lax` always, and `Secure` when the page is served over HTTPS.

```diff
-document.cookie = `${name}=${value};${expires};path=/`
+const secure = window.location.protocol === 'https:' ? ';Secure' : ''
+document.cookie = `${name}=${value};${expires};path=/;SameSite=Lax${secure}`
```

## Why the `Secure` attribute is conditional

An unconditional `;Secure` would clear the Snyk finding, but it changes behaviour for anyone serving the page over plain HTTP on a non-localhost origin — most realistically a developer testing across devices on `http://192.168.x.x:3000`. The browser would silently refuse to store the cookie, so the alert would reappear on every page load with no error to explain it.

Gating on the protocol avoids that with no security cost. On an HTTP page the document and all its traffic are already plaintext, so `Secure` protects nothing there; on HTTPS, which is every real NSW Government service, the attribute is applied and the finding is addressed.

`SameSite=Lax` is unconditional. Chrome and Firefox already treat attribute-less cookies as Lax, so this makes the current effective behaviour explicit rather than changing it.

## Verification

Snyk Code, scanned against `src/components/global-alert` before and after:

| | Result |
|---|---|
| Before (`master`) | 1 issue — `javascript/WebCookieSecureDisabledByDefault`, Low, CWE-614, `global-alert.js:35` |
| After (this branch) | 0 issues |

The control scan matters here: the conditional could in principle have still tripped the rule, since the ternary sometimes yields an empty string. It doesn't — Snyk resolves it and the finding clears.

`npx tsc --noEmit` passes.

## Notes for review

- No `dist` rebuild is included — `dist` is gitignored and produced at release.
- No `CHANGELOG.md` edit — it is generated by `auto-changelog` at release time, so this PR title becomes the entry.
- `HttpOnly` is deliberately not set. The cookie is written from client-side JavaScript and has to stay readable by `getCookie()` on the next page load.

## Testing

1. Serve the docs site over HTTPS and dismiss a global alert that has `data-cookie-name` set.
2. Confirm in DevTools → Application → Cookies that the cookie carries `Secure` and `SameSite=Lax`.
3. Reload and confirm the alert stays hidden.
4. Repeat over plain HTTP on a LAN IP and confirm the alert still stays hidden after reload, i.e. no change from current behaviour.
